### PR TITLE
Add another rule for URL encoded resource identifiers

### DIFF
--- a/app/processors/gitlab_processor.py
+++ b/app/processors/gitlab_processor.py
@@ -18,6 +18,10 @@ SPECIAL_ROUTE_RULES = [
     {
         'before': 'repository/files/',
         'after': '/raw'
+    },
+    {
+        'before': 'repository/files/',
+        'after': ''
     }
 ]
 


### PR DESCRIPTION
Add special rule for path encoding to fix queries for base64 encoded repo files.