### PR TITLE
token_expired response

### DIFF
--- a/app/auth/web.py
+++ b/app/auth/web.py
@@ -167,11 +167,18 @@ def get_tokens():
 @app.route(urljoin(app.config['SERVICE_PREFIX'], 'auth/token/refresh'))
 def refresh_tokens():
     headers = dict(request.headers)
-    new_tokens = get_refreshed_tokens(headers)
-    response = json.dumps({
-        'access_token': new_tokens['access_token'],
-        'refresh_token': new_tokens['refresh_token']
-    })
+    refresh_token_response = get_refreshed_tokens(headers)
+    try:
+        response = json.dumps({
+            'access_token': refresh_token_response['access_token'],
+            'refresh_token': refresh_token_response['refresh_token']
+        })
+        return Response(response)
+    except KeyError:
+        response = json.dumps({
+            'error': refresh_token_response['error'],
+            'error_description': refresh_token_response['error_description']
+        })
     return Response(response)
 
 

--- a/app/gateway/proxy.py
+++ b/app/gateway/proxy.py
@@ -20,6 +20,7 @@
 import logging
 import importlib
 import json
+import jwt
 from flask import request, Response
 from urllib.parse import urljoin
 
@@ -71,6 +72,8 @@ def pass_through(path):
     if auth:
         try:
             headers = auth.process(request, headers)
+        except jwt.ExpiredSignatureError:
+            return Response(json.dumps({'error': 'token_expired'}), status=401)
         except:
             logger.warning("Error while authenticating request", exc_info=True)
             return Response(json.dumps({'error': "Error while authenticating"}), status=401)


### PR DESCRIPTION
Send {'error': 'token_expired'} response on expired access_token.

Closes #39