### PR TITLE
Forward the pagination headers in the GitLab response

### DIFF
--- a/app/processors/base_processor.py
+++ b/app/processors/base_processor.py
@@ -13,6 +13,9 @@ class BaseProcessor:
     def __init__(self, path, endpoint):
         self.path = path
         self.endpoint = endpoint
+        self.forwarded_headers = [
+            'Content-Type',
+        ]
         logger.debug('Processor with path = "{}" and endpoint = "{}"'.format(path, endpoint))
 
     def process(self, request, headers):
@@ -31,16 +34,24 @@ class BaseProcessor:
             timeout=300
         )
 
-        rsp = Response(self.generate(response), response.status_code)
-        # rsp.headers = Headers(response.headers.lower_items())  # this seems to break things sometimes
-
         logger.debug('Response: {}'.format(response.status_code))
-        logger.debug('Response headers: {}'.format(rsp.headers))
+        logger.debug('Response headers: {}'.format(response.headers))
 
-        return rsp
+        return Response(
+            response=self.generate_response_data(response),
+            headers=self.create_response_headers(response),
+            status=response.status_code,
+        )
 
-    def generate(self, response):
+    def generate_response_data(self, response):
         for c in response.iter_lines():
             # logger.debug(c)
             yield c + "\r\n".encode()
         yield "\r\n".encode()
+
+    def create_response_headers(self, response):
+        headers = Headers()
+        for header in response.headers:
+            if header in self.forwarded_headers:
+                headers.add(header, response.headers[header])
+        return headers

--- a/app/processors/gitlab_processor.py
+++ b/app/processors/gitlab_processor.py
@@ -9,6 +9,7 @@ import requests
 import re
 
 from flask import Response
+from werkzeug.datastructures import Headers
 
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,16 @@ SPECIAL_ROUTE_REGEXES = [
     '(.*)({before})(.*)({after})(.*)'.format(before=rule['before'], after=rule['after']) for rule in SPECIAL_ROUTE_RULES
 ]
 
+GITLAB_FORWARDED_RESPONSE_HEADERS = [
+    'Link',
+    'X-Next-Page',
+    'X-Page',
+    'X-Per-Page',
+    'X-Prev-Page',
+    'X-Total',
+    'X-Total-Pages'
+]
+
 
 def urlencode_paths(path):
     """Urlencode some paths before forwarding requests."""
@@ -45,7 +56,23 @@ def urlencode_paths(path):
     return path
 
 
+def fix_link_header(headers):
+    """Replace the GitLab URL in the Link header."""
+
+    if 'Link' in headers:
+        headers['Link'] = headers['Link'].replace(
+            app.config['GITLAB_URL'], app.config['HOST_NAME']
+        )
+
+    return headers
+
+
 class GitlabGeneric(BaseProcessor):
+
+    def __init__(self, path, endpoint):
+        super().__init__(path, endpoint)
+        self.forwarded_headers += GITLAB_FORWARDED_RESPONSE_HEADERS
+
 
     def process(self, request, headers):
         # Gitlab has routes where the resource identifier can include slashes
@@ -55,6 +82,11 @@ class GitlabGeneric(BaseProcessor):
 
         self.endpoint = urljoin(self.endpoint.format(**app.config), self.path)
         return super().process(request, headers)
+
+    def create_response_headers(self, response):
+        headers = super().create_response_headers(response)
+        headers = fix_link_header(headers)
+        return headers
 
 
 class GitlabProjects(BaseProcessor):


### PR DESCRIPTION
Forward pagination headers in the response, modify URLs in the `Link` header such that they point to a gateway URL.