### PR TITLE
Moving to a stateful gateway

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,10 +8,11 @@ Werkzeug = "*"
 hypercorn = "*"
 oic = "*"
 requests = "*"
-blinker = "*"
 quart = "*"
 Quart-CORS = "*"
 PyJWT = "*"
+redis = "*"
+flask_kvsession = "*"
 
 [dev-packages]
 pytest = "*"
@@ -19,6 +20,7 @@ pytest_asyncio = "*"
 nose = "*"
 chartpress = "*"
 responses = "*"
+mockredispy = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "166d981ac2656903b44d5dff3e615622870e132372fe22b744ca8c5eadd6ab51"
+            "sha256": "4c18ced05768b045105ccfb13ad843033ca29ec5fbfb3757e713e22fdd5c5f7c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,10 +25,10 @@
         },
         "alabaster": {
             "hashes": [
-                "sha256:674bb3bab080f598371f4443c5008cbfeb1a5e622dd312395d2d82af2c54c456",
-                "sha256:b63b1f4dc77c074d386752ec4a8a7517600f6c0db8cd42980cae17ab7b3275d7"
+                "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
+                "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
             ],
-            "version": "==0.7.11"
+            "version": "==0.7.12"
         },
         "asn1crypto": {
             "hashes": [
@@ -47,7 +47,6 @@
             "hashes": [
                 "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
             ],
-            "index": "pypi",
             "version": "==1.4"
         },
         "certifi": {
@@ -92,6 +91,7 @@
                 "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
                 "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
             ],
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7'",
             "version": "==1.11.5"
         },
         "chardet": {
@@ -103,10 +103,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
-                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
-            "version": "==6.7"
+            "markers": "python_version != '3.1.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*'",
+            "version": "==7.0"
         },
         "cryptography": {
             "hashes": [
@@ -130,7 +131,21 @@
                 "sha256:e79ab4485b99eacb2166f3212218dd858258f374855e1568f728462b0e6ee0d9",
                 "sha256:f995d3667301e1754c57b04e0bae6f0fa9d710697a9f8d6712e8cca02550910f"
             ],
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7'",
             "version": "==2.3.1"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
+                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+            ],
+            "version": "==1.0.2"
+        },
+        "flask-kvsession": {
+            "hashes": [
+                "sha256:9c0ee93fae089c45baeda0a3fd3ae32a96ee81c34996017749f8b3fd06df936c"
+            ],
+            "version": "==0.6.2"
         },
         "future": {
             "hashes": [
@@ -140,10 +155,10 @@
         },
         "h11": {
             "hashes": [
-                "sha256:1c0fbb1cba6f809fe3e6b27f8f6d517ca171f848922708871403636143d530d9",
-                "sha256:af77d5d82fa027c032650fb8afdef3cd0a3735ba01480bee908cddad9be1bdce"
+                "sha256:acca6a44cb52a32ab442b1779adf0875c443c689e9e028f8d831a3769f9c5208",
+                "sha256:f2b1ca39bfed357d1f19ac732913d5f9faa54a5062eca7d2ec3a916cfb7ae4c7"
             ],
-            "version": "==0.7.0"
+            "version": "==0.8.1"
         },
         "h2": {
             "hashes": [
@@ -161,11 +176,11 @@
         },
         "hypercorn": {
             "hashes": [
-                "sha256:74390b2dfc3412a950b40cdc516afa49eaf943b9d604826c9260c3a108ce0878",
-                "sha256:8d9e4fb9d41c9a3f37d007ba0be1c91d7b05e2fe0e6568ebfe04734f6d604ccc"
+                "sha256:2a15eac76ffab59efa7b126a322637e42afa12bbef3de6bef51f1a014c8f2e06",
+                "sha256:3a6fddd23b2018aee03503352ecdee5bc0e21be2fbaa0a01cb9e1555bd0d4d01"
             ],
             "index": "pypi",
-            "version": "==0.2.4"
+            "version": "==0.3.2"
         },
         "hyperframe": {
             "hashes": [
@@ -208,22 +223,38 @@
         },
         "multidict": {
             "hashes": [
-                "sha256:1a1d76374a1e7fe93acef96b354a03c1d7f83e7512e225a527d283da0d7ba5e0",
-                "sha256:1d6e191965505652f194bc4c40270a842922685918a4f45e6936a6b15cc5816d",
-                "sha256:295961a6a88f1199e19968e15d9b42f3a191c89ec13034dbc212bf9c394c3c82",
-                "sha256:2be5af084de6c3b8e20d6421cb0346378a9c867dcf7c86030d6b0b550f9888e4",
-                "sha256:2eb99617c7a0e9f2b90b64bc1fb742611718618572747d6f3d6532b7b78755ab",
-                "sha256:4ba654c6b5ad1ae4a4d792abeb695b29ce981bb0f157a41d0fd227b385f2bef0",
-                "sha256:5ba766433c30d703f6b2c17eb0b6826c6f898e5f58d89373e235f07764952314",
-                "sha256:a59d58ee85b11f337b54933e8d758b2356fcdcc493248e004c9c5e5d11eedbe4",
-                "sha256:a6e35d28900cf87bcc11e6ca9e474db0099b78f0be0a41d95bef02d49101b5b2",
-                "sha256:b4df7ca9c01018a51e43937eaa41f2f5dce17a6382fda0086403bcb1f5c2cf8e",
-                "sha256:bbd5a6bffd3ba8bfe75b16b5e28af15265538e8be011b0b9fddc7d86a453fd4a",
-                "sha256:d870f399fcd58a1889e93008762a3b9a27cf7ea512818fc6e689f59495648355",
-                "sha256:e9404e2e19e901121c3c5c6cffd5a8ae0d1d67919c970e3b3262231175713068"
+                "sha256:05eeab69bf2b0664644c62bd92fabb045163e5b8d4376a31dfb52ce0210ced7b",
+                "sha256:0c85880efa7cadb18e3b5eef0aa075dc9c0a3064cbbaef2e20be264b9cf47a64",
+                "sha256:136f5a4a6a4adeacc4dc820b8b22f0a378fb74f326e259c54d1817639d1d40a0",
+                "sha256:14906ad3347c7d03e9101749b16611cf2028547716d0840838d3c5e2b3b0f2d3",
+                "sha256:1ade4a3b71b1bf9e90c5f3d034a87fe4949c087ef1f6cd727fdd766fe8bbd121",
+                "sha256:22939a00a511a59f9ecc0158b8db728afef57975ce3782b3a265a319d05b9b12",
+                "sha256:2b86b02d872bc5ba5b3a4530f6a7ba0b541458ab4f7c1429a12ac326231203f7",
+                "sha256:3c11e92c3dfc321014e22fb442bc9eb70e01af30d6ce442026b0c35723448c66",
+                "sha256:4ba3bd26f282b201fdbce351f1c5d17ceb224cbedb73d6e96e6ce391b354aacc",
+                "sha256:4c6e78d042e93751f60672989efbd6a6bc54213ed7ff695fff82784bbb9ea035",
+                "sha256:4d80d1901b89cc935a6cf5b9fd89df66565272722fe2e5473168927a9937e0ca",
+                "sha256:4fcf71d33178a00cc34a57b29f5dab1734b9ce0f1c97fb34666deefac6f92037",
+                "sha256:52f7670b41d4b4d97866ebc38121de8bcb9813128b7c4942b07794d08193c0ab",
+                "sha256:5368e2b7649a26b7253c6c9e53241248aab9da49099442f5be238fde436f18c9",
+                "sha256:5bb65fbb48999044938f0c0508e929b14a9b8bf4939d8263e9ea6691f7b54663",
+                "sha256:60672bb5577472800fcca1ac9dae232d1461db9f20f055184be8ce54b0052572",
+                "sha256:669e9be6d148fc0283f53e17dd140cde4dc7c87edac8319147edd5aa2a830771",
+                "sha256:6a0b7a804e8d1716aa2c72e73210b48be83d25ba9ec5cf52cf91122285707bb1",
+                "sha256:79034ea3da3cf2a815e3e52afdc1f6c1894468c98bdce5d2546fa2342585497f",
+                "sha256:79247feeef6abcc11137ad17922e865052f23447152059402fc320f99ff544bb",
+                "sha256:81671c2049e6bf42c7fd11a060f8bc58f58b7b3d6f3f951fc0b15e376a6a5a98",
+                "sha256:82ac4a5cb56cc9280d4ae52c2d2ebcd6e0668dd0f9ef17f0a9d7c82bd61e24fa",
+                "sha256:9436267dbbaa49dad18fbbb54f85386b0f5818d055e7b8e01d219661b6745279",
+                "sha256:94e4140bb1343115a1afd6d84ebf8fca5fb7bfb50e1c2cbd6f2fb5d3117ef102",
+                "sha256:a2cab366eae8a0ffe0813fd8e335cf0d6b9bb6c5227315f53bb457519b811537",
+                "sha256:a596019c3eafb1b0ae07db9f55a08578b43c79adb1fe1ab1fd818430ae59ee6f",
+                "sha256:e8848ae3cd6a784c29fae5055028bee9bffcc704d8bcad09bd46b42b44a833e2",
+                "sha256:e8a048bfd7d5a280f27527d11449a509ddedf08b58a09a24314828631c099306",
+                "sha256:f6dd28a0ac60e2426a6918f36f1b4e2620fc785a0de7654cd206ba842eee57fd"
             ],
             "markers": "python_version >= '3.4.1'",
-            "version": "==4.3.1"
+            "version": "==4.4.2"
         },
         "oic": {
             "hashes": [
@@ -234,9 +265,10 @@
         },
         "pycparser": {
             "hashes": [
-                "sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
             ],
-            "version": "==2.18"
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7'",
+            "version": "==2.19"
         },
         "pycryptodomex": {
             "hashes": [
@@ -277,7 +309,6 @@
             "hashes": [
                 "sha256:128e3c81d02993ac4cd7e29ef7aac767d91daa59380e6883ae589092945e4aad"
             ],
-            "markers": "python_version < '4' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version >= '2.6' and python_version != '3.1.*'",
             "version": "==1.4.0"
         },
         "pyjwt": {
@@ -293,21 +324,22 @@
                 "sha256:26ff56a6b5ecaf3a2a59f132681e2a80afcc76b4f902f612f518f92c2a1bf854",
                 "sha256:6488f1423b00f73b7ad5167885312bb0ce410d3312eb212393795b53c8caa580"
             ],
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7'",
             "version": "==18.0.0"
         },
         "pytoml": {
             "hashes": [
-                "sha256:dae3c4e31d09eb06a6076d671f2281ee5d2c43cbeae16599c3af20881bb818ac"
+                "sha256:42f76a696182570e93581e763da033c1de484973bad82458387b6dee6c184cbc"
             ],
-            "version": "==0.1.18"
+            "version": "==0.1.19"
         },
         "quart": {
             "hashes": [
-                "sha256:349e4c39519fd4feff366c5acca606d33c2a024de43eb6364bfaa7cf54796d4b",
-                "sha256:850b6cacaf02689c615f71fd7f4cebcf8d41f3fa4c7cb86f4d234734006ea24a"
+                "sha256:8450ab5fdc61f4e49b2d99240af164c8bd36e85ceac2e655ed1c70a7fdaca038",
+                "sha256:b5317dc860f02687c95ae444291080f98407935bea4fff78d8ce183596483fd5"
             ],
             "index": "pypi",
-            "version": "==0.6.6"
+            "version": "==0.6.7"
         },
         "quart-cors": {
             "hashes": [
@@ -317,6 +349,14 @@
             "index": "pypi",
             "version": "==0.1.0"
         },
+        "redis": {
+            "hashes": [
+                "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
+                "sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f"
+            ],
+            "index": "pypi",
+            "version": "==2.10.6"
+        },
         "requests": {
             "hashes": [
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
@@ -324,6 +364,14 @@
             ],
             "index": "pypi",
             "version": "==2.19.1"
+        },
+        "simplekv": {
+            "hashes": [
+                "sha256:0148f9c6222bb6bededc46131e3f67ae28c4be912f977770bfe0fa70c470c251",
+                "sha256:903bef61523f8a19069fed6d6b6b9f2a43102d441b4d9f39cb41ad00725aacd6",
+                "sha256:a8b16e4941d9c178e974e56f92b3e05ed0d454f30e2f0a174eef39b505da2228"
+            ],
+            "version": "==0.11.10"
         },
         "six": {
             "hashes": [
@@ -334,25 +382,25 @@
         },
         "sortedcontainers": {
             "hashes": [
-                "sha256:607294c6e291a270948420f7ffa1fb3ed47384a4c08db6d1e9c92d08a6981982",
-                "sha256:ef38b128302ee8f65d81e31c9d8fbf10d81df4d6d06c9c0b66f01d33747525bb"
+                "sha256:220bb2e3e1886297fd7cdd6d164cb5cf237be1cfae1a3a3e526d149c52816682",
+                "sha256:b74f2756fb5e23512572cc76f0fe0832fd86310f77dfee54335a35fb33f6b950"
             ],
-            "version": "==2.0.4"
+            "version": "==2.0.5"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:1c0a8e3b4ce55207a03dd0dcb98bc47a704c71f14fe4311ec860cc8af8f4bd27",
-                "sha256:8b0962ecb92847974514b1724c8ae2b6dd1ffe86bcdfac429517f5e583ada658",
-                "sha256:be7b05ddab71727fabf1f071365043cf034e4cdac9cade1f1d61a6cc526aaafe"
+                "sha256:2a6c6e78e291a4b6cbd0bbfd30edc0baaa366de962129506ec8fe06bdec66457",
+                "sha256:51e7b7f3dcabf9ad22eed61490f3b8d23d9922af400fe6656cb08e66656b701f",
+                "sha256:55401f6ed58ade5638eb566615c150ba13624e2f0c1eedd080fc3c1b6cb76f1d"
             ],
-            "version": "==3.6.5"
+            "version": "==3.6.6"
         },
         "urllib3": {
             "hashes": [
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version < '4' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version >= '2.6' and python_version != '3.1.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.6'",
             "version": "==1.23"
         },
         "werkzeug": {
@@ -365,10 +413,10 @@
         },
         "wsproto": {
             "hashes": [
-                "sha256:02f214f6bb43cda62a511e2e8f1d5fa4703ed83d376d18d042bd2bbf2e995824",
-                "sha256:d2a7f718ab3144ec956a3267d57b5c172f0668827f5803e7d670837b0125b9fa"
+                "sha256:1fcb726d448f1b9bcbea884e26621af5ddd01d2d502941a024f4c727828b6009",
+                "sha256:6a51cf18d9de612892b9c1d38a8c1bdadec0cfe15de61cd5c0f09174bf0c7e82"
             ],
-            "version": "==0.11.0"
+            "version": "==0.12.0"
         }
     },
     "develop": {
@@ -377,7 +425,7 @@
                 "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
                 "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.7'",
             "version": "==1.2.1"
         },
         "attrs": {
@@ -423,6 +471,13 @@
             ],
             "version": "==2.7"
         },
+        "mockredispy": {
+            "hashes": [
+                "sha256:8caefadab8f32bd41bbccbcc9615347dd4f840cfedc253f43a4675f07036a446"
+            ],
+            "index": "pypi",
+            "version": "==2.9.3"
+        },
         "more-itertools": {
             "hashes": [
                 "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
@@ -445,7 +500,7 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.7'",
             "version": "==0.7.1"
         },
         "py": {
@@ -453,22 +508,23 @@
                 "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
                 "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.7'",
             "version": "==1.6.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:2d7c49e931316cc7d1638a3e5f54f5d7b4e5225972b3c9838f3584788d27f349",
-                "sha256:ad0c7db7b5d4081631e0155f5c61b80ad76ce148551aaafe3a718d65a7508b18"
+                "sha256:7e258ee50338f4e46957f9e09a0f10fb1c2d05493fa901d113a8dafd0790de4e",
+                "sha256:9332147e9af2dcf46cd7ceb14d5acadb6564744ddff1fe8c17f0ce60ece7d9a2"
             ],
             "index": "pypi",
-            "version": "==3.7.4"
+            "version": "==3.8.2"
         },
         "pytest-asyncio": {
             "hashes": [
                 "sha256:a962e8e1b6ec28648c8fe214edab4e16bacdb37b52df26eb9d63050af309b2a9",
                 "sha256:fbd92c067c16111174a1286bfb253660f1e564e5146b39eeed1133315cf2c2cf"
             ],
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.7'",
             "version": "==0.9.0"
         },
         "requests": {
@@ -489,30 +545,30 @@
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:36f26a9788f005b70e5f8dd4b42588032f3290884955a19ea21339dd7a2a91bd",
-                "sha256:37dc87cd78bb6160606dfbd2b015015cf1441872133950ecb4a837a90d694670",
-                "sha256:3a2ae6ac6f1cd7e26dd1c7a5249080ff269a903e43c237e575239bc42c85d65c",
-                "sha256:42765a674a5ab4dd7bd6de837c93f2911f6114bb040a07a71379b1577b3b2e36",
-                "sha256:57f7578af7a71a562d64f78c4a72589d55d471650c19f0fc54e0d2e6c7e5f1f5",
-                "sha256:66692fc9608c3d7002d5502dea45d3c81fb6158781f65de4d984af41a2e800c8",
-                "sha256:6719c43f0fb41436759823a7c01258152d18e5f8368e89cd5b1eda5e03734403",
-                "sha256:6cc5d81f3dac5bf0d387df68dd973bee80ded42f1f83474e59e948450646a805",
-                "sha256:7a42648c994e99a0b59237f1c10eafeb08475db09ecabf92cd1176693782cd23",
-                "sha256:7d276cfbbf2a373d6cd02263509b1435ecb7725143a7d3e0bf627f9f3de39bc7",
-                "sha256:8bd4c97e44514f1d977576799fdd8e8f2b2654a4cd52c0d91c8b7e1c6bcea9ed",
-                "sha256:aa0ca65adf6dfb511e1de9adb04d64a65b7bf2cc007cd942caaa9a004b43dfeb",
-                "sha256:aec20e594f604f13e6bd44fff42bfa865ff04b22e93722fc4f744a97bb0bc9cf",
-                "sha256:aef5a5816680f4c77f872f7f805bbbafc813e9c9cb3405cc9b7507c1680fe7d3",
-                "sha256:b7fbb5574c8e87e5acc4cb201ca84a1cfb8b967543dd7861fb20743977ea0701",
-                "sha256:cdce01701ad52a3771393db7feac7d41caa083ba683bd3f16f6647347cab2387",
-                "sha256:ebbb6527bf12df4835cf7ab001736ba7af657cbf8814354e36e0b8267fb433ca",
-                "sha256:f1c55e2422ff879dbc6751fbd05a38455a7f870351afff29bcc38df336c3b86c",
-                "sha256:f6c372edc30b25b884b4bd7556c4eb5b426516e44bf5856601ec5642ffa36905",
-                "sha256:f9e07c9ba68a94e8b075e1ecf004c211db864246fc65ddf66976b38e82a5242b",
-                "sha256:fa77530ae18c8e4f1b6596eb77a1cdcbac16f400ef6b48ada0c803533deb5c60",
-                "sha256:fae2d856c8542a5b5684f1c8f36c538a965068dda39d25a3a82373f05fcf2983"
+                "sha256:10a8912a32f51eed40e32aa76e2700bb7bfc92f321a0e98409e3b1132bac4519",
+                "sha256:1224d1f6abefda0de53ded39e51fc5e0bc0bb496f9e2f6566d3abe2f03cf54c8",
+                "sha256:1d51f69dd8dd6fc58b8b3ca7aef87580b940ad0764ac1ea86f8b64feb555d5db",
+                "sha256:3bc6377f623e48959bbc4eca07db614c9c0e374b9eea79feff93258aebafc38d",
+                "sha256:3df98993f7e20864e60cba10606e14ad109175bb78c1129b06d38a0492beac36",
+                "sha256:4796caffcbb81929d8be643df46c74f1825fff4dc0f7e132ea10f727ef89a0cd",
+                "sha256:57d1a4c2d158f53040a9d8a611e79a1235be3418a1f8370145493adbab0ebbeb",
+                "sha256:6655d70b2e2f6b40220ea4c6caac5bed15cb477bbaf7c6687029f3c82a45bca0",
+                "sha256:7eff959cf0a792cb5650b5f50cc8bb5c53b3ab136695268c66ccd3cd332ba2b9",
+                "sha256:867e2d0f7d5b4b3dbd9810fa601a9cb663ca8eec45c1f4b3bf56281894c47119",
+                "sha256:97652b9e3a76958cf6684d5d963674adf345d8cc192ddd95e2a21b22cda29f40",
+                "sha256:9e5179afa032cd64216f9c508b5428cbe3cc42bb6b7dbb33e7cbf64c38eb2f2d",
+                "sha256:a2fbb7e2e09390758f704dd04a17643108a3494292c49e9f4a10f248316ec2ae",
+                "sha256:a3fde21c981928fde30c5ddded90d313487522c3e7b2011b20b4a17d82e14926",
+                "sha256:ab0353559bd1a47e67e287090daa04bed7c19ec887bf311010fe69ddb40fd8eb",
+                "sha256:ab7ef6d1ca0dc914fd66eacc8a5cfbf47f5530fe106c81f645b55cff2e1da984",
+                "sha256:ab993f82687407dd8f478fb1c1213735524b10f1aa296391261838ee41331ed0",
+                "sha256:bd76a9aee355306bfc173865e891885a63888ee15b0e358a66d697bb5c9e208a",
+                "sha256:c1483c3de2010b5eb7dfbf6a2484e59d96c5c3a96f67b6ef4dd801471a21195b",
+                "sha256:dbf52838c2fd987417cf820aed3a7dea0ba19dfe47c978361afb00cc1366264b",
+                "sha256:edce27e000efe88d280e05984175a38835b32929be5c893a8dab6d5af4090995",
+                "sha256:f037812ac7360201eef2aa6d977836b2a31419c65ce706c5e0bfb176a99efa04"
             ],
-            "version": "==0.15.64"
+            "version": "==0.15.72"
         },
         "six": {
             "hashes": [
@@ -526,7 +582,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version < '4' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version >= '2.6' and python_version != '3.1.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.6'",
             "version": "==1.23"
         }
     }

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,7 +36,7 @@ app = Quart(__name__)
 for key in config.keys():
     app.config[key] = config[key]
 
-app = cors(app, allow_headers=['X-Requested-With'], allow_origin="*")
+app = cors(app, allow_headers=['X-Requested-With'], allow_origin=app.config['ALLOW_ORIGIN'])
 
 load_config()
 

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -16,5 +16,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """auth module."""
-from .gitlab_auth import GitlabSudoToken
+from .gitlab_auth import GitlabUserToken
 from .keycloak_auth import KeycloakAccessToken

--- a/app/auth/gitlab_auth.py
+++ b/app/auth/gitlab_auth.py
@@ -52,9 +52,9 @@ class GitlabUserToken():
                 audience=app.config['OIDC_CLIENT_ID']
             )
 
-            # TODO: maybe add a way to verify if the token is still valid ? (it is not JWT)
             gl_token = store.get(get_key_for_user(decodentoken, 'gl_access_token'))
             headers['Authorization'] = "Bearer {}".format(gl_token.decode())
+            headers['Renku-Token'] = access_token  # can be needed later in the request processing
 
         else:
             # logger.debug("No authorization header, returning empty auth headers")
@@ -151,6 +151,11 @@ def gitlab_get_tokens():
 
 
 def get_gitlab_refresh_token(access_token):
+    access_token = jwt.decode(
+        access_token, app.config['OIDC_PUBLIC_KEY'],
+        algorithms='RS256',
+        audience=app.config['OIDC_CLIENT_ID']
+    )
     to = Token(resp={'refresh_token': store.get(get_key_for_user(access_token, 'gl_refresh_token'))})
     refresh_token_response = gitlab_client.do_access_token_refresh(token=to)
     if 'access_token' in refresh_token_response:

--- a/app/auth/keycloak_auth.py
+++ b/app/auth/keycloak_auth.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from .web import get_refreshed_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +23,5 @@ logger = logging.getLogger(__name__)
 class KeycloakAccessToken():
 
     def process(self, request, headers):
-
-        new_tokens = get_refreshed_tokens(headers)
-        if new_tokens:
-            headers['Authorization'] = "Bearer {}".format(new_tokens.get('access_token'))
 
         return headers

--- a/app/auth/web.py
+++ b/app/auth/web.py
@@ -166,6 +166,7 @@ async def login():
     auth_req = client.construct_AuthorizationRequest(request_args=args)
     login_url = auth_req.request(client.authorization_endpoint)
     response = await app.make_response(redirect(login_url))
+
     return response
 
 
@@ -274,7 +275,6 @@ async def logout():
 
     # cleanup the session in redis immediately
     cookie_val = request.cookies.get('session').split(".")[0]
-    app.permanent_session_lifetime = timedelta(seconds=1)
     store.delete(cookie_val)
     session.clear()
 

--- a/app/config.py
+++ b/app/config.py
@@ -30,10 +30,27 @@ logger = getLogger(__name__)
 
 
 config = dict()
+
 config['HOST_NAME'] = os.environ.get('HOST_NAME', 'http://gateway.renku.build')
+
+config['SECRET_KEY'] = os.environ.get('GATEWAY_SECRET_KEY', 'dummy-secret')
+
+# We need to specify that the cookie is valid for all .renku.build subdomains
+if 'gateway.renku.build' in config['HOST_NAME']:
+    config['SESSION_COOKIE_DOMAIN'] = '.'.join([''] + config['HOST_NAME'].split('.')[1:])
+else:
+    config['SESSION_COOKIE_DOMAIN'] = None
+
+config['SESSION_COOKIE_HTTPONLY'] = True
+config['SESSION_COOKIE_SECURE'] = config['HOST_NAME'].startswith('https')
+
+config['REDIS_HOST'] = os.environ.get('GATEWAY_REDIS_HOST', 'renku-gw-redis')
+
 config['RENKU_ENDPOINT'] = os.environ.get('RENKU_ENDPOINT', 'http://renku.build')
 config['GITLAB_URL'] = os.environ.get('GITLAB_URL', 'http://gitlab.renku.build')
 config['GITLAB_PASS'] = os.environ.get('GITLAB_PASS', 'dummy-secret')
+config['GITLAB_CLIENT_ID'] = os.environ.get('GITLAB_CLIENT_ID', 'renku-ui')
+config['GITLAB_CLIENT_SECRET'] = os.environ.get('GITLAB_CLIENT_SECRET', 'no-secret-needed')
 
 config['OIDC_ISSUER'] = os.environ.get('KEYCLOAK_URL', 'http://keycloak.renku.build:8080') \
                         + '/auth/realms/Renku'

--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,8 @@ else:
 config['SESSION_COOKIE_HTTPONLY'] = True
 config['SESSION_COOKIE_SECURE'] = config['HOST_NAME'].startswith('https')
 
+config['ALLOW_ORIGIN'] = os.environ.get('GATEWAY_ALLOW_ORIGIN', "").split(',')
+
 config['REDIS_HOST'] = os.environ.get('GATEWAY_REDIS_HOST', 'renku-gw-redis')
 
 config['RENKU_ENDPOINT'] = os.environ.get('RENKU_ENDPOINT', 'http://renku.build')

--- a/app/processors/gitlab_processor.py
+++ b/app/processors/gitlab_processor.py
@@ -93,7 +93,7 @@ class GitlabProjects(BaseProcessor):
 
     async def process(self, request, headers):
         endpoint = self.endpoint.format(**app.config)
-        if 'Sudo' in headers:
+        if 'Authorization' in headers:
             project_response = requests.request(
                 request.method,
                 endpoint,

--- a/app/tests/test_proxy.py
+++ b/app/tests/test_proxy.py
@@ -103,6 +103,9 @@ async def test_gitlab_happyflow(client):
     access_token = jwt.encode(payload=TOKEN_PAYLOAD, key=PRIVATE_KEY, algorithm='RS256').decode('utf-8')
     headers = {'Authorization': 'Bearer {}'.format(access_token)}
 
+    from .. import store
+    store.put('cache_5dbdeba7-e40f-42a7-b46b-6b8a07c65966_gl_access_token', 'some_token'.encode())
+
     responses.add(responses.GET, app.config['GITLAB_URL'] + '/api/v4/projects', json=GITLAB_PROJECTS, status=200)
     responses.add(responses.GET, app.config['GITLAB_URL'] + "/api/v4/projects/1/repository/files/README.md/raw?ref=master", body="test", status=200)
     responses.add(responses.GET, app.config['GITLAB_URL'] + "/api/v4/projects/1/issues?scope=all", json=GITLAB_ISSUES, status=200)

--- a/endpoints.json
+++ b/endpoints.json
@@ -12,6 +12,6 @@
     "(/)?": {
         "endpoint": "{GITLAB_URL}/api/",
         "processor": "app.processors.GitlabGeneric",
-        "auth": "app.auth.GitlabSudoToken"
+        "auth": "app.auth.GitlabUserToken"
     }
 }

--- a/helm-chart/minikube-values.yaml
+++ b/helm-chart/minikube-values.yaml
@@ -5,5 +5,7 @@ global:
 gitlabUrl: "http://gitlab.renku.build"
 keycloakUrl: "http://keycloak.renku.build:8080"
 
+secretKey: "dummy-secret"
+
 ingress:
   enabled: false

--- a/helm-chart/renku-gateway/Chart.yaml
+++ b/helm-chart/renku-gateway/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku gateway
 name: renku-gateway
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.0-unclean-fd237f2
+version: 0.2.1

--- a/helm-chart/renku-gateway/Chart.yaml
+++ b/helm-chart/renku-gateway/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku gateway
 name: renku-gateway
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.2.0
+version: 0.0-unclean-fd237f2

--- a/helm-chart/renku-gateway/requirements.lock
+++ b/helm-chart/renku-gateway/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 3.7.2
+digest: sha256:0fd490e3f2effaf0ee234577830ec7b0674698f9fc74dcf1f876860721181fe8
+generated: 2018-09-24T13:54:13.380379241+02:00

--- a/helm-chart/renku-gateway/requirements.yaml
+++ b/helm-chart/renku-gateway/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: redis
+  version: 3.7.2
+  repository: "@stable"

--- a/helm-chart/renku-gateway/templates/_helpers.tpl
+++ b/helm-chart/renku-gateway/templates/_helpers.tpl
@@ -41,3 +41,13 @@ https
 http
 {{- end -}}
 {{- end -}}
+
+{{/*
+Hack for calling templates in a fake scope (until this is solved https://github.com/helm/helm/issues/4535)
+*/}}
+{{- define "call-nested" }}
+{{- $dot := index . 0 }}
+{{- $subchart := index . 1 }}
+{{- $template := index . 2 }}
+{{- include $template (dict "Chart" (dict "Name" $subchart) "Values" (index $dot.Values $subchart) "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
+{{- end }}

--- a/helm-chart/renku-gateway/templates/deployment.yaml
+++ b/helm-chart/renku-gateway/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: {{ template "gateway.name" . }}
         release: {{ .Release.Name }}
+        {{ include "call-nested" (list . "redis" "redis.fullname") }}-client: "true"
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -34,6 +35,10 @@ spec:
               value: {{ .Values.renkuEndpoint | default (printf "%s://%s" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
             - name: GITLAB_URL
               value: {{ .Values.gitlabUrl | default (printf "%s://%s/gitlab" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
+            - name: GITLAB_CLIENT_SECRET
+              value: {{ .Values.gitlabClientSecret | default .Values.global.gateway.gitlabClientSecret | quote }}
+            - name: GITLAB_CLIENT_ID
+              value: {{ .Values.gitlabClientId | default .Values.global.gateway.gitlabClientId | quote }}
             - name: GITLAB_PASS
               value: {{ .Values.gitlabSudoToken | default .Values.global.gitlab.sudoToken | quote }}
             - name: JUPYTERHUB_URL
@@ -46,6 +51,10 @@ spec:
               value: {{ .Values.oidcClientSecret | default .Values.global.gateway.clientSecret | quote }}
             - name: OIDC_CLIENT_ID
               value: {{ .Values.oidcClientId | default "gateway" | quote }}
+            - name: GATEWAY_REDIS_HOST
+              value: {{ include "call-nested" (list . "redis" "redis.fullname") }}-master
+            - name: GATEWAY_SECRET_KEY
+              value: {{ .Values.secretKey | quote }}
           livenessProbe:
             httpGet:
               path: /health

--- a/helm-chart/renku-gateway/templates/deployment.yaml
+++ b/helm-chart/renku-gateway/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: {{ include "call-nested" (list . "redis" "redis.fullname") }}-master
             - name: GATEWAY_SECRET_KEY
               value: {{ .Values.secretKey | quote }}
+            - name: GATEWAY_ALLOW_ORIGIN
+              value: {{ .Values.allowOrigin | quote }}
           livenessProbe:
             httpGet:
               path: /health

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -35,15 +35,19 @@ replicaCount: 1
 # baseUrl: "http://127.0.0.1:8080"
 ## Set to a custom GitLab URL if deployed manually
 # gitlabUrl: "http://gitlab.renku.build"
+
 ## Configure application ID from "{{ gitlabUrl }}/oauth/application"
 ## by setting redirect URL to "{{ baseUrl }}/login/redirect/gitlab"
 ## and set the application ID as the "gitlabClientId" chart value.
-# gitlabClientId: "renku-gateway"
+## The client ID for authentication against gitlab
+# gitlabClientId: renku-ui
+## The client secret for authentication against gitlab
+# gitlabClientSecret: no-secret
 
 image:
   name: renku/renku-gateway
   repository: renku/renku-gateway
-  tag: '0.2.0'
+  tag: 0.0-unclean-fd237f2
   pullPolicy: IfNotPresent
 
 service:
@@ -67,3 +71,20 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+redis:
+
+  nameOverride: gw-redis
+
+  cluster:
+    enabled: false
+
+  usePassword: false
+
+  master:
+    persistence:
+      enabled: false
+
+  networkPolicy:
+    enabled: true
+    allowExternal: false

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -44,10 +44,14 @@ replicaCount: 1
 ## The client secret for authentication against gitlab
 # gitlabClientSecret: no-secret
 
+## You can restrict here the allowed origins for CORS.
+## This can be a single value, a comma-separeted list or *.
+# allowOrigin: "*"
+
 image:
   name: renku/renku-gateway
   repository: renku/renku-gateway
-  tag: 0.0-unclean-fd237f2
+  tag: '0.2.1'
   pullPolicy: IfNotPresent
 
 service:

--- a/run-telepresence.sh
+++ b/run-telepresence.sh
@@ -21,6 +21,10 @@ set -e
 MINIKUBE_IP=`minikube ip`
 CURRENT_CONTEXT=`kubectl config current-context`
 
+# On Mac we can not use `pipenv run quart run` because of
+# https://www.telepresence.io/reference/methods
+QUART_EXECUTABLE=`pipenv --venv`/bin/quart
+
 echo "You are going to exchange k8s deployments using the following context: ${CURRENT_CONTEXT}"
 read -p "Do you want to proceed? [y/n]"
 if [[ ! $REPLY =~ ^[Yy]$ ]]
@@ -32,13 +36,8 @@ echo "==========================================================================
 echo "Once telepresence has started, copy-paste the following command to start the development server:"
 echo "QUART_DEBUG=1 \
 QUART_APP=run:app.app \
-HOST_NAME=http://${MINIKUBE_IP} \
-RENKU_ENDPOINT=http://${MINIKUBE_IP} \
-GITLAB_URL=http://${MINIKUBE_IP}/gitlab \
-KEYCLOAK_URL=http://${MINIKUBE_IP} \
-GATEWAY_SERVICE_PREFIX=/api/ \
 PYTHONASYNCIODEBUG=1 \
-pipenv run quart run"
+${QUART_EXECUTABLE} run"
 echo "================================================================================================================="
 
 telepresence --swap-deployment renku-gateway --namespace renku --method inject-tcp --expose 5000 --run-shell


### PR DESCRIPTION
- Adds redis as a session backend for storing the users' identity as KC refresh_token (making the server side session expires with the refresh token). 
- Store the various user tokens also in redis.
- It also removes the need for blinker and the signals as well as the global variables, making it possible to have several instance of the gateway (sharing the redis instance/cluster).
- TODOS:
  - [x]  merge https://github.com/SwissDataScienceCenter/renku/pull/428
  - [x]  add "{GATEWAY_URL}/api/auth/gitlab/token" and "read_repository read_registry openid" to the scopes of the renku-ui client in gitlab. -> (https://github.com/SwissDataScienceCenter/renku/pull/440)
  - [x] mock redis for the tests.
  - [ ] merge with: https://github.com/SwissDataScienceCenter/renku-ui/pull/331