### PR TITLE
Fix url encoding of groups names in gitlab

### DIFF
--- a/app/processors/gitlab_processor.py
+++ b/app/processors/gitlab_processor.py
@@ -23,7 +23,19 @@ SPECIAL_ROUTE_RULES = [
     {
         'before': 'repository/files/',
         'after': ''
-    }
+    },
+    {
+        'before': 'groups/',
+        'after': '/projects'
+    },
+    {
+        'before': 'groups/',
+        'after': '/subgroups'
+    },
+    {
+        'before': 'groups/',
+        'after': ''
+    },
 ]
 
 SPECIAL_ROUTE_REGEXES = [


### PR DESCRIPTION
closes #61 