### PR TITLE
Shorten request timeouts

### DIFF
--- a/app/helpers/gitlab_client.py
+++ b/app/helpers/gitlab_client.py
@@ -27,11 +27,11 @@ def get_readme(headers, projectid):
     readme_url = app.config['GITLAB_URL'] + "/api/v4/projects/" + str(projectid) + "/repository/files/README.md/raw?ref=master"
     logger.debug("Getting readme for project with {0}". format(projectid) )
 
-    return requests.request(request.method, readme_url, headers=headers, data=request.data, stream=True, timeout=300)
+    return requests.request(request.method, readme_url, headers=headers, data=request.data, stream=True, timeout=30)
 
 
 def get_kus(headers, projectid):
     ku_url = app.config['GITLAB_URL'] + "/api/v4/projects/" + str(projectid) + "/issues?scope=all"
     logger.debug("Getting issues for project with id {0}". format(projectid) )
 
-    return requests.request(request.method, ku_url, headers=headers, data=request.data, stream=True, timeout=300)
+    return requests.request(request.method, ku_url, headers=headers, data=request.data, stream=True, timeout=30)

--- a/app/helpers/gitlab_parsers.py
+++ b/app/helpers/gitlab_parsers.py
@@ -42,7 +42,7 @@ def parse_ku(headers, ku):
     projectid = ku['project_id']
 
     reactions_url = app.config['GITLAB_URL'] + "/api/v4/projects/" + str(projectid) + "/issues/" + str(kuid) +  "/award_emoji"
-    reactions_response = (requests.request(request.method, reactions_url, headers=headers, data=request.data, stream=True, timeout=300))
+    reactions_response = (requests.request(request.method, reactions_url, headers=headers, data=request.data, stream=True, timeout=30))
 
     if reactions_response.status_code == 200:
         reactions = reactions_response.json()
@@ -50,7 +50,7 @@ def parse_ku(headers, ku):
         reactions = []
 
     contribution_url =  app.config['GITLAB_URL'] + "/api/v4/projects/" + str(projectid) + "/issues/" + str(kuid) + "/notes"
-    contribution_response = (requests.request(request.method, contribution_url, headers=headers, data=request.data, stream=True, timeout=300))
+    contribution_response = (requests.request(request.method, contribution_url, headers=headers, data=request.data, stream=True, timeout=30))
 
     if contribution_response.status_code == 200:
         contributions = [parse_contribution(headers, x) for x in contribution_response.json()]
@@ -132,7 +132,7 @@ def parse_contribution(headers, contribution):
 def parse_user(headers, user_id):
 
     user_url =  app.config['GITLAB_URL'] + "api/v4/users" + str(user_id)
-    user = (requests.request(request.method, user_url, headers=headers, data=request.data, stream=True, timeout=300)).json()
+    user = (requests.request(request.method, user_url, headers=headers, data=request.data, stream=True, timeout=30)).json()
 
     return {
         'metadata': {

--- a/app/processors/base_processor.py
+++ b/app/processors/base_processor.py
@@ -44,7 +44,7 @@ class BaseProcessor:
             params=request.args,
             data=(await request.data),
             stream=True,
-            timeout=300
+            timeout=30
         )
 
         logger.debug('Response: {}'.format(response.status_code))

--- a/app/processors/gitlab_processor.py
+++ b/app/processors/gitlab_processor.py
@@ -121,7 +121,7 @@ class GitlabProjects(BaseProcessor):
                 headers=headers,
                 data=request.data,
                 stream=True,
-                timeout=300
+                timeout=30
             )
             projects_list = project_response.json()
             logger.debug("Gitlab response: {}".format(projects_list))


### PR DESCRIPTION
Set all request timeouts to 30 instead of 300 seconds.
Note that for streaming requests, the timeout does NOT refer to the duration of the entire response streaming but only the first byte being transferred, see: http://docs.python-requests.org/en/master/user/advanced/#timeouts