### PR TITLE
Enable HEAD requests to gitlab.

### DIFF
--- a/app/blueprints/__init__.py
+++ b/app/blueprints/__init__.py
@@ -17,4 +17,4 @@
 # limitations under the License.
 
 # We define a list of all HTTP methods which are forwarded per default here.
-ALL_HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE']
+ALL_HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD']

--- a/app/processors/gitlab_processor.py
+++ b/app/processors/gitlab_processor.py
@@ -100,6 +100,11 @@ class GitlabGeneric(BaseProcessor):
 
     def create_response_headers(self, response):
         headers = super().create_response_headers(response)
+
+        # We add back all gitlab-specific headers
+        for header_name in response.headers:
+            if header_name.startswith('X-Gitlab'):
+                headers[header_name] = response.headers[header_name]
         headers = fix_link_header(headers)
         return headers
 


### PR DESCRIPTION
This is used to get meta-information about a repository file without transferring the entire file.