### PR TITLE
Fix logging

### DIFF
--- a/app/auth/gitlab_auth.py
+++ b/app/auth/gitlab_auth.py
@@ -18,7 +18,6 @@
 """Implement GitLab authentication workflow."""
 
 import json
-import logging
 import re
 import urllib
 from urllib.parse import urljoin
@@ -36,8 +35,6 @@ from quart import (
 
 from .web import JWT_ALGORITHM, get_key_for_user
 
-logger = logging.getLogger(__name__)
-
 blueprint = Blueprint('gitlab_auth', __name__, url_prefix='/auth/gitlab')
 
 
@@ -54,7 +51,7 @@ class GitlabUserToken():
             re.IGNORECASE
         )
         if m:
-            # logger.debug('outgoing headers: {}'.format(json.dumps(headers))
+            # current_app.logger.debug('outgoing headers: {}'.format(json.dumps(headers))
             access_token = m.group('token')
             decodentoken = jwt.decode(
                 access_token,
@@ -75,7 +72,7 @@ class GitlabUserToken():
             ] = access_token  # can be needed later in the request processing
 
         else:
-            # logger.debug("No authorization header, returning empty auth headers")
+            # current_app.logger.debug("No authorization header, returning empty auth headers")
             pass
 
         return headers

--- a/app/auth/jupyterhub_auth.py
+++ b/app/auth/jupyterhub_auth.py
@@ -18,24 +18,21 @@
 """Implement JupyterHub authentication workflow."""
 
 import json
-import logging
 import re
 from urllib.parse import parse_qs, urlencode, urljoin
 
 import jwt
 import requests
 from oic import rndstr
-from quart import Blueprint, redirect, request, session, url_for
+from quart import Blueprint, redirect, request, session, url_for, current_app
 
 from .web import JWT_ALGORITHM, get_key_for_user
 
-logger = logging.getLogger(__name__)
 
 blueprint = Blueprint(
     'jupyterhub_auth', __name__, url_prefix='/auth/jupyterhub'
 )
 
-from quart import current_app
 
 class JupyterhubUserToken():
     def process(self, request, headers):
@@ -46,7 +43,7 @@ class JupyterhubUserToken():
             re.IGNORECASE
         )
         if m:
-            # logger.debug('Authorization header present, token exchange')
+            # current_app.logger.debug('Authorization header present, token exchange')
             access_token = m.group('token')
             decodentoken = jwt.decode(
                 access_token,
@@ -60,9 +57,9 @@ class JupyterhubUserToken():
             )
             headers['Authorization'] = "token {}".format(jh_token.decode())
 
-            # logger.debug('outgoing headers: {}'.format(json.dumps(headers)))
+            # current_app.logger.debug('outgoing headers: {}'.format(json.dumps(headers)))
         else:
-            # logger.debug("No authorization header, returning empty auth headers")
+            # current_app.logger.debug("No authorization header, returning empty auth headers")
             headers.pop('Authorization', None)
 
         return headers

--- a/app/auth/keycloak_auth.py
+++ b/app/auth/keycloak_auth.py
@@ -15,12 +15,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
-
-logger = logging.getLogger(__name__)
 
 
 class KeycloakAccessToken():
     def process(self, request, headers):
-
         return headers

--- a/app/auth/web.py
+++ b/app/auth/web.py
@@ -18,7 +18,6 @@
 """Web auth routes."""
 
 import json
-import logging
 import re
 import time
 import urllib.parse
@@ -35,7 +34,6 @@ from quart import (
     session, url_for
 )
 
-logger = logging.getLogger(__name__)
 
 blueprint = Blueprint('web_auth', __name__, url_prefix='/auth')
 
@@ -80,7 +78,7 @@ def get_valid_token(headers):
         if jwt.decode(
             m.group('token'), verify=False
         ).get('typ') in ['Offline', 'Refresh']:
-            logger.debug("Swapping the token")
+            current_app.logger.debug("Swapping the token")
             to = Token(resp={'refresh_token': m.group('token')})
             token_response = client.do_access_token_refresh(token=to)
 
@@ -128,7 +126,7 @@ def get_valid_token(headers):
                     get_key_for_user(a, 'kc_refresh_token')
                 ).decode()
 
-                logger.debug("Refreshing the token")
+                current_app.logger.debug("Refreshing the token")
                 to = Token(resp={'refresh_token': refresh_token})
 
                 token_response = client.do_access_token_refresh(token=to)
@@ -260,7 +258,7 @@ async def token():
 
     # we can already tell the CLI which token to use
     if session.get('cli_token'):
-        logger.debug(
+        current_app.logger.debug(
             "Notification for request {}".format(session.get('cli_token'))
         )
 
@@ -286,7 +284,7 @@ async def info():
     if t:
         timeout = 120
         key = "cli_{}".format(hashlib.sha256(t.encode()).hexdigest())
-        logger.debug("Waiting for Keycloak callback for request {}".format(t))
+        current_app.logger.debug("Waiting for Keycloak callback for request {}".format(t))
         val = store.get(key)
         while not val and timeout > 0:
             time.sleep(3)
@@ -296,7 +294,7 @@ async def info():
             store.delete(key)
             return val
         else:
-            logger.debug("Timeout while waiting for request {}".format(t))
+            current_app.logger.debug("Timeout while waiting for request {}".format(t))
             return '{"error": "timeout"}'
     else:
 

--- a/app/blueprints/graph.py
+++ b/app/blueprints/graph.py
@@ -17,12 +17,8 @@
 # limitations under the License.
 """Graph endpoint."""
 
-import logging
 from quart import Blueprint, current_app, jsonify, request
 from SPARQLWrapper import DIGEST, JSON, POST, SPARQLWrapper
-
-
-logger = logging.getLogger(__name__)
 
 blueprint = Blueprint('graph', __name__, url_prefix='/graph')
 

--- a/app/config.py
+++ b/app/config.py
@@ -19,125 +19,73 @@
 
 import os
 import sys
-from logging import getLogger
-from time import sleep
+import warnings
 
-import requests
 
-logger = getLogger(__name__)
-
-config = dict()
-
-config['HOST_NAME'] = os.environ.get('HOST_NAME', 'http://gateway.renku.build')
+HOST_NAME = os.environ.get('HOST_NAME', 'http://gateway.renku.build')
 
 if 'GATEWAY_SECRET_KEY' not in os.environ and "pytest" not in sys.modules:
-    logger.critical(
+    warnings.warn(
         'The environment variable GATEWAY_SECRET_KEY is not set. '
         'It is mandatory for securely signing session cookie.'
     )
-    exit(2)
-config['SECRET_KEY'] = os.environ.get('GATEWAY_SECRET_KEY')
+    sys.exit(2)
+SECRET_KEY = os.environ.get('GATEWAY_SECRET_KEY')
 
-# We need to specify that the cookie is valid for all .renku.build subdomains
-if 'gateway.renku.build' in config['HOST_NAME']:
-    config['SESSION_COOKIE_DOMAIN'] = '.'.join([''] + config['HOST_NAME'].
-                                               split('.')[1:])
-else:
-    config['SESSION_COOKIE_DOMAIN'] = None
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SECURE = HOST_NAME.startswith('https')
 
-config['SESSION_COOKIE_HTTPONLY'] = True
-config['SESSION_COOKIE_SECURE'] = config['HOST_NAME'].startswith('https')
+ALLOW_ORIGIN = os.environ.get('GATEWAY_ALLOW_ORIGIN', "").split(',')
 
-config['ALLOW_ORIGIN'] = os.environ.get('GATEWAY_ALLOW_ORIGIN', "").split(',')
+REDIS_HOST = os.environ.get('GATEWAY_REDIS_HOST', 'renku-gw-redis')
 
-config['REDIS_HOST'] = os.environ.get('GATEWAY_REDIS_HOST', 'renku-gw-redis')
+RENKU_ENDPOINT = os.environ.get(
+        'RENKU_ENDPOINT', 'http://renku.build'
+    )
+GITLAB_URL = os.environ.get(
+        'GITLAB_URL', 'http://gitlab.renku.build'
+    )
 
-config['RENKU_ENDPOINT'] = os.environ.get(
-    'RENKU_ENDPOINT', 'http://renku.build'
-)
-config['GITLAB_URL'] = os.environ.get(
-    'GITLAB_URL', 'http://gitlab.renku.build'
-)
-
-config['GITLAB_CLIENT_ID'] = os.environ.get('GITLAB_CLIENT_ID', 'renku-ui')
-config['GITLAB_CLIENT_SECRET'] = os.environ.get(
-    'GITLAB_CLIENT_SECRET', 'no-secret-needed'
-)
-if 'GITLAB_CLIENT_SECRET' not in os.environ:
-    logger.warning(
+GITLAB_CLIENT_ID = os.environ.get('GITLAB_CLIENT_ID', 'renku-ui')
+GITLAB_CLIENT_SECRET = os.environ.get('GITLAB_CLIENT_SECRET')
+if not GITLAB_CLIENT_SECRET:
+    warnings.warn(
         'The environment variable GITLAB_CLIENT_SECRET is not set.'
         'It is mandatory for Gitlab login.'
     )
 
-config['JUPYTERHUB_URL'] = os.environ.get(
-    'JUPYTERHUB_URL', '{}/jupyterhub'.format(config['HOST_NAME'])
-)
-config['JUPYTERHUB_CLIENT_ID'] = os.environ.get(
-    'JUPYTERHUB_CLIENT_ID', 'gateway'
-)
-config['JUPYTERHUB_CLIENT_SECRET'] = os.environ.get(
-    'JUPYTERHUB_CLIENT_SECRET', 'dummy-secret'
-)
-if 'JUPYTERHUB_CLIENT_SECRET' not in os.environ:
-    logger.warning(
+JUPYTERHUB_URL = os.environ.get(
+        'JUPYTERHUB_URL', '{}/jupyterhub'.format(HOST_NAME)
+    )
+JUPYTERHUB_CLIENT_ID = os.environ.get(
+        'JUPYTERHUB_CLIENT_ID', 'gateway'
+    )
+JUPYTERHUB_CLIENT_SECRET = os.environ.get('JUPYTERHUB_CLIENT_SECRET')
+if not JUPYTERHUB_CLIENT_SECRET:
+    warnings.warn(
         'The environment variable JUPYTERHUB_CLIENT_SECRET is not set. '
         'It is mandatory for JupyterHub login.'
     )
 
-config['WEBHOOK_SERVICE_HOSTNAME'] = os.environ.get(
-    'WEBHOOK_SERVICE_HOSTNAME', 'http://renku-graph-webhooks-service'
-)
+WEBHOOK_SERVICE_HOSTNAME = os.environ.get(
+        'WEBHOOK_SERVICE_HOSTNAME', 'http://renku-graph-webhooks-service'
+    )
 
-config['SPARQL_ENDPOINT'] = os.environ.get(
-    'SPARQL_ENDPOINT', 'http://localhost:3030/renku/sparql'
-)
-config['SPARQL_USERNAME'] = os.environ.get('SPARQL_USERNAME', 'admin')
-config['SPARQL_PASSWORD'] = os.environ.get('SPARQL_PASSWORD', 'admin')
+SPARQL_ENDPOINT = os.environ.get(
+        'SPARQL_ENDPOINT', 'http://localhost:3030/renku/sparql'
+    )
+SPARQL_USERNAME = os.environ.get('SPARQL_USERNAME', 'admin')
+SPARQL_PASSWORD = os.environ.get('SPARQL_PASSWORD', 'admin')
 
-config['OIDC_ISSUER'] = os.environ.get(
-    'KEYCLOAK_URL', 'http://keycloak.renku.build:8080'
-) + '/auth/realms/Renku'
-config['OIDC_CLIENT_ID'] = os.environ.get('OIDC_CLIENT_ID', 'gateway')
-config['OIDC_CLIENT_SECRET'] = os.environ.get(
-    'OIDC_CLIENT_SECRET', 'dummy-secret'
-)
-if 'OIDC_CLIENT_SECRET' not in os.environ:
-    logger.warning(
+OIDC_ISSUER = os.environ.get(
+        'KEYCLOAK_URL', 'http://keycloak.renku.build:8080'
+    ) + '/auth/realms/Renku'
+OIDC_CLIENT_ID = os.environ.get('OIDC_CLIENT_ID', 'gateway')
+OIDC_CLIENT_SECRET = os.environ.get('OIDC_CLIENT_SECRET')
+if not OIDC_CLIENT_SECRET:
+    warnings.warn(
         'The environment variable OIDC_CLIENT_SECRET is not set. '
         'It is mandatory for OpenId-Connect login.'
     )
 
-config['SERVICE_PREFIX'] = os.environ.get('GATEWAY_SERVICE_PREFIX', '/')
-
-# Get the public key of the OIDC provider to verify access- and refresh_tokens
-# TODO: The public key of the OIDC provider should go to the app context
-#       and be refreshed
-# TODO: regularly or whenever the validation of a token fails and
-#       the public key has not been
-# TODO: updated in a while.
-
-
-if "pytest" in sys.modules:
-    okKey = True
-else:
-    okKey = False
-attempts = 0
-
-while attempts < 20 and not okKey:
-    attempts += 1
-    try:
-        raw_key = requests.get(config['OIDC_ISSUER']).json()['public_key']
-        config[
-            'OIDC_PUBLIC_KEY'
-        ] = '-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----'.format(
-            raw_key
-        )
-        okKey = True
-        logger.info('Obtained public key from Keycloak.')
-    except:
-        logger.info('Could not get public key from Keycloak, trying again...')
-        sleep(10)
-
-if not okKey:
-    logger.info('Could not get public key from Keycloak, giving up.')
-    exit(1)
+SERVICE_PREFIX = os.environ.get('GATEWAY_SERVICE_PREFIX', '/')

--- a/app/gateway/proxy.py
+++ b/app/gateway/proxy.py
@@ -18,7 +18,6 @@
 """Gateway logic."""
 
 import json
-import logging
 import re
 
 import jwt
@@ -26,16 +25,9 @@ from quart import Response, current_app
 
 from app.auth.web import get_valid_token
 
-logger = logging.getLogger(__name__)
-
 
 async def pass_through(request, processor, auth):
     headers = dict(request.headers)
-
-    # Keycloak public key is not defined so error
-    if current_app.config['OIDC_PUBLIC_KEY'] is None:
-        response = json.dumps("Ooops, something went wrong internally.")
-        return Response(response, status=500)
 
     if 'Host' in headers:
         del headers['Host']
@@ -80,7 +72,7 @@ async def pass_through(request, processor, auth):
         except jwt.ExpiredSignatureError:
             return Response(json.dumps({'error': 'token_expired'}), status=401)
         except:
-            logger.warning("Error while authenticating request", exc_info=True)
+            current_app.logger.warning("Error while authenticating request", exc_info=True)
             return Response(
                 json.dumps({
                     'error': "Error while authenticating"

--- a/app/processors/base_processor.py
+++ b/app/processors/base_processor.py
@@ -1,14 +1,12 @@
 import os
 import json
-import logging
 
 import aiohttp
-from quart import Response
+from quart import Response, current_app
 from werkzeug.datastructures import Headers
 
 gateway_env = os.environ.get('GATEWAY_ENV')
 dev_env = (gateway_env == 'development')
-logger = logging.getLogger(__name__)
 
 
 def headers_for_development(headers):
@@ -24,20 +22,20 @@ class BaseProcessor:
         self.forwarded_headers = [
             'Content-Type',
         ]
-        logger.debug(
+        current_app.logger.debug(
             'Processor with path = "{}" and endpoint = "{}"'.format(
                 path, endpoint
             )
         )
 
     async def process(self, request, headers):
-        logger.debug('Request path: {}'.format(self.path))
-        logger.debug('Forward endpoint: {}'.format(self.endpoint))
-        logger.debug('incoming headers: {}'.format(json.dumps(headers)))
+        current_app.logger.debug('Request path: {}'.format(self.path))
+        current_app.logger.debug('Forward endpoint: {}'.format(self.endpoint))
+        current_app.logger.debug('incoming headers: {}'.format(json.dumps(headers)))
 
         if dev_env:
             headers = headers_for_development(headers)
-            logger.debug('development headers: {}'.format(json.dumps(headers)))
+            current_app.logger.debug('development headers: {}'.format(json.dumps(headers)))
 
         async with aiohttp.ClientSession() as session:
             async with session.request(
@@ -50,8 +48,8 @@ class BaseProcessor:
 
                 response_data = await response.read()
 
-                logger.debug('Response: {}'.format(response.status))
-                logger.debug('Response headers: {}'.format(response.headers))
+                current_app.logger.debug('Response: {}'.format(response.status))
+                current_app.logger.debug('Response headers: {}'.format(response.headers))
 
                 return Response(
                     # response=response_generator(response),

--- a/app/processors/gitlab_processor.py
+++ b/app/processors/gitlab_processor.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import re
 from urllib.parse import quote, urljoin
 
@@ -10,8 +9,6 @@ from werkzeug.datastructures import Headers
 # from app.helpers.gitlab_parsers import parse_project
 from app.processors.base_processor import BaseProcessor
 
-
-logger = logging.getLogger(__name__)
 
 SPECIAL_ROUTE_RULES = [
     {

--- a/app/tests/test_proxy.py
+++ b/app/tests/test_proxy.py
@@ -85,7 +85,6 @@ async def test_passthrough_nopubkeyflow(client):
     path = urljoin(app.config['SERVICE_PREFIX'], 'v4/projects/')
     rv = await client.get(path)
     assert rv.status_code == 500
-    assert b'"Ooops, something went wrong internally' in (await rv.get_data())
 
 
 ## TODO: currently no endpoint absolutely requires a token


### PR DESCRIPTION
- Remove side effects during imports
- Check for a keycloak public key before_request() if it is not part of the app context already
- Use standard quart app.logger everywhere except during module import
- Use warnings.warn() for warnings during import

This fixes the logging problems that have partially prevented logs from showing up in production.
Closes #106 and #98. A better logging strategy should be introduced later (see #113).