### PR TITLE
Activate access logs in traefik

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -19,6 +19,8 @@ data:
     [entrypoints]
       [entrypoints.http]
         address = ":{{ .Values.service.port }}"
+    [accessLog]
+      bufferingSize = 10
     [http.routers]
       [http.routers.gateway]
         entryPoints = ["http"]


### PR DESCRIPTION
Change traefik config to enable access logs. Buffered (size 10) logs are written to stdout and thus picked up by k8s.