### PR TITLE
Disable watching of the traefik config file

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -14,7 +14,11 @@ data:
       dashboard = true
     [providers]
       [providers.file]
-        watch = true
+        # Having file watching enabled prevents traefik from
+        # starting properly for our maxikube deployment (travis ci/cd)
+        # Not sure if this is a traefik bug or a problem with our maxikube
+        # deployment though.
+        watch = false
         directory = "/config"
     [entrypoints]
       [entrypoints.http]


### PR DESCRIPTION
Watching /config/traefik.toml (which is on per default) would be desirable as it would automatically pick up changes in the corresponding configmap. However, having file watching enabled currently breaks the deployments that are autmatically created as a part of the travis CI/CD pipeline on the main Renku repository.
So far, all other deployments seem to be ok with the watch = true setting though...