### PR TITLE
Base-64 encode redis keys

### DIFF
--- a/app/auth/web.py
+++ b/app/auth/web.py
@@ -170,7 +170,11 @@ def get_valid_token(headers):
 
 
 def get_key_for_user(token, name):
-    return "cache_{}_{}".format(token.get('sub'), name)
+    """ Create a base-64 encoded key for the redis store """
+    from base64 import b64encode
+    key = 'cache_{}_{}'.format(token.get('sub'), name)
+    return b64encode(key.encode()).decode('utf-8')
+
 
 
 LOGIN_SEQUENCE = ['gitlab_auth.login', 'jupyterhub_auth.login']

--- a/app/tests/test_proxy.py
+++ b/app/tests/test_proxy.py
@@ -106,7 +106,14 @@ async def test_gitlab_happyflow(client):
     headers = {'Authorization': 'Bearer {}'.format(access_token)}
 
     from .. import store
-    store.put('cache_5dbdeba7-e40f-42a7-b46b-6b8a07c65966_gl_access_token', 'some_token'.encode())
+    from base64 import b64encode
+    store.put(
+        b64encode(
+            'cache_5dbdeba7-e40f-42a7-b46b-6b8a07c65966_gl_access_token'
+            .encode()
+        ).decode('utf-8'),
+        'some_token'.encode()
+    )
 
     rv = await client.get('/?auth=gitlab', headers=headers)
 


### PR DESCRIPTION
Federated identities can come with characters that are not supported as redis keys. Base 64 encoding those keys solves that issue.