### PR TITLE
Fix traefik routing for gitlab

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -79,7 +79,7 @@ data:
       [http.middlewares.development.headers]
         isDevelopment = true
       [http.middlewares.gitlab.AddPrefix]
-        prefix = "/gitlab/api/v4"
+        prefix = "{{ .Values.global.gitlab.urlPrefix }}/api/v4"
       [http.middlewares.jupyterhub.ReplacePathRegex]
         regex = "^/jupyterhub/(.*)"
         replacement = "/jupyterhub/hub/api/$1"

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -7,6 +7,9 @@
 global:
   ## Set to true if using https
   useHTTPS: false
+  ## The URL path prefix under which gitlab is running.
+  gitlab:
+    urlPrefix: /gitlab
   gateway:
     ## Client secret of the renku client application registered in
     ## keycloak.


### PR DESCRIPTION
Fix the traefik routing for gitlab for cases where gitlab is running under a different hosname instead of under the /gitlab path.

Note: This is a stripped down version of #142 that does not need any upstream chart changes. I tested it in our regular dev setup and in a minikube setup where Renku was deployed against gitlab.com.

Addresses #138 (fixes it for gitlab only)