### PR TITLE
feat: make Keycloak realm configurable

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -74,9 +74,14 @@ SPARQL_ENDPOINT = os.environ.get(
 SPARQL_USERNAME = os.environ.get('SPARQL_USERNAME', 'admin')
 SPARQL_PASSWORD = os.environ.get('SPARQL_PASSWORD', 'admin')
 
-OIDC_ISSUER = os.environ.get(
-        'KEYCLOAK_URL', 'http://keycloak.renku.build:8080'
-    ) + '/auth/realms/Renku'
+KEYCLOAK_URL = os.environ.get('KEYCLOAK_URL')
+if not KEYCLOAK_URL:
+    warnings.warn(
+        'The environment variable KEYCLOAK_URL is not set. '
+        'It is necessary because Keycloak acts as identity provider for Renku.'
+    )
+KEYCLOAK_REALM = os.environ.get('KEYCLOAK_REALM', 'Renku')
+OIDC_ISSUER = '{}/auth/realms/{}'.format(KEYCLOAK_URL, KEYCLOAK_REALM)
 OIDC_CLIENT_ID = os.environ.get('OIDC_CLIENT_ID', 'gateway')
 OIDC_CLIENT_SECRET = os.environ.get('OIDC_CLIENT_SECRET')
 if not OIDC_CLIENT_SECRET:

--- a/helm-chart/renku-gateway/Chart.yaml
+++ b/helm-chart/renku-gateway/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '2.0'
 description: A Helm chart for the Renku gateway
 name: renku-gateway
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.4.0
+version: 0.4.1

--- a/helm-chart/renku-gateway/templates/deployment.yaml
+++ b/helm-chart/renku-gateway/templates/deployment.yaml
@@ -125,6 +125,10 @@ spec:
               value: {{ .Values.jupyterhub.clientId | quote }}
             - name: KEYCLOAK_URL
               value: {{ .Values.keycloakUrl | default (printf "%s://%s" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
+              {{ if .Values.global.keycloak.realm }}
+            - name: KEYCLOAK_REALM
+              value: {{ .Values.global.keycloak.realm | quote }}
+              {{ end }}
             - name: GATEWAY_SERVICE_PREFIX
               value: {{ .Values.gatewayServicePrefix | default "/api/" | quote }}
             - name: GATEWAY_REDIS_HOST

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -23,6 +23,14 @@ global:
     ## set by parent chart.
     domain: example.local
 
+    ## Set the Keycloak Realm name used by Renku here - the default 
+    ## value is "Renku" and is set on the application level. You may 
+    ## override this here if you are using an external Keycloak instance 
+    ## and want to use an existing realm. If Keycloak is deployed as a 
+    ## part of Renku DO NOT change this value.
+    # keycloak:
+    #   realm: Renku
+
 replicaCount: 1
 
 ## Set to true to enable the developement mode. This has negative security


### PR DESCRIPTION
So far the use of a Keycloak realm called 'Renku' was hardcoded. This can now be set through the charts, the default is set at the application level to 'Renku'.

Closes #147 