### PR TITLE
Improve traefik settings

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -13,111 +13,138 @@ data:
     {{ if .Values.development }}
     [Global]
       debug = true
+
     [log]
       level = "debug"
     {{ else }}
     [log]
       level = "error"
     {{ end }}
+
     [api]
       dashboard = true
+
     [providers]
       [providers.file]
-        # Having file watching enabled prevents traefik from
-        # starting properly for our maxikube deployment (travis ci/cd)
-        # Not sure if this is a traefik bug or a problem with our maxikube
-        # deployment though.
-        watch = false
         directory = "/config"
+        filename = "rules.toml"
+
     [entrypoints]
       [entrypoints.http]
         address = ":{{ .Values.service.port }}"
+
     [accessLog]
       bufferingSize = 10
-    [http.routers]
-      [http.routers.gateway]
-        entryPoints = ["http"]
-        Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}auth`) || PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}graph`)"
-        Service = "gateway"
-      [http.routers.jupyterhub]
-        entryPoints = ["http"]
-        Middlewares = ["auth-jupyterhub", "common", "jupyterhub" ]
-        Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}jupyterhub`)"
-        Service = "jupyterhub"
-      [http.routers.notebooks]
-        entryPoints = ["http"]
-        Middlewares = ["auth-jupyterhub", "common", "notebooks"]
-        Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}notebooks`)"
-        Service = "jupyterhub"
-      [http.routers.webhooks]
-        entryPoints = ["http"]
-        Middlewares = ["auth-gitlab", "common", "webhooks"]
-        Rule = "Path(`{{ .Values.gatewayServicePrefix | default "/api/" }}projects/{project-id}/graph/webhooks{endpoint:(.*)}`)"
-        Service = "webhooks"
-      [http.routers.graphstatus]
-        entryPoints = ["http"]
-        Middlewares = ["auth-gitlab", "common", "graphstatus"]
-        Rule = "Path(`{{ .Values.gatewayServicePrefix | default "/api/" }}projects/{project-id}/graph/status{endpoint:(.*)}`)"
-        Service = "webhooks"
-      [http.routers.gitlab]
-        entryPoints = ["http"]
-        Middlewares = ["auth-gitlab", "common", "gitlab"]
-        Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}`)"
-        Service = "gitlab"
-    [http.middlewares]
-      [http.middlewares.common.chain]
-        {{- if .Values.development }}
-        middlewares = ["api", "noCookies", "development"]
-        {{- else }}
-        middlewares = ["api", "noCookies"]
-        {{- end }}
-      [http.middlewares.noCookies.headers]
-        [http.middlewares.noCookies.headers.CustomRequestHeaders]
-          Cookie = ""
-      [http.middlewares.api.StripPrefix]
-        prefixes = ["/api"]
-      [http.middlewares.development.headers]
-        isDevelopment = true
-      [http.middlewares.gitlab.AddPrefix]
-        prefix = "{{ .Values.global.gitlab.urlPrefix }}/api/v4"
-      [http.middlewares.jupyterhub.ReplacePathRegex]
-        regex = "^/jupyterhub/(.*)"
-        replacement = "/jupyterhub/hub/api/$1"
-      [http.middlewares.notebooks.ReplacePathRegex]
-        regex = "^/notebooks/(.*)"
-        replacement = "/jupyterhub/services/notebooks/$1"
-      [http.middlewares.auth-gitlab.forwardauth]
-        address = "http://{{ template "gateway.fullname" . }}-auth/?auth=gitlab"
-        trustForwardHeader = true
-        authResponseHeaders = ["Authorization"]
-      [http.middlewares.auth-jupyterhub.forwardauth]
-        address = "http://{{ template "gateway.fullname" . }}-auth/?auth=jupyterhub"
-        trustForwardHeader = true
-        authResponseHeaders = ["Authorization"]
-      [http.middlewares.webhooks.ReplacePathRegex]
-        regex = "^/projects/([^/]*)/graph/webhooks(.*)"
-        replacement = "/projects/$1/webhooks$2"
-      [http.middlewares.graphstatus.ReplacePathRegex]
-        regex = "^/projects/([^/]*)/graph(.*)"
-        replacement = "/projects/$1/events$2"
-    [http.services]
-      [http.services.gateway.LoadBalancer]
-        method = "drr"
-        [[http.services.gateway.LoadBalancer.servers]]
-          url = "http://{{ template "gateway.fullname" . }}-auth/"
-          weight = 1
-      [http.services.gitlab.LoadBalancer]
-        method = "drr"
-        [[http.services.gitlab.LoadBalancer.servers]]
-          url = {{ .Values.gitlabUrl | default (printf "%s://%s/gitlab" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
-          weight = 1
-      [http.services.jupyterhub.LoadBalancer]
-        method = "drr"
-        [[http.services.jupyterhub.LoadBalancer.servers]]
-          url = {{ .Values.jupyterhub.url | default (printf "%s://%s/jupyterhub" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
-          weight = 1
-      [http.services.webhooks.LoadBalancer]
-        method = "drr"
-        [[http.services.webhooks.LoadBalancer.servers]]
-          url = {{ .Values.graph.webhookService.hostname | default (printf "http://%s-graph-webhook-service" .Release.Name ) | quote }}
-          weight = 1
+
+  rules.toml: |
+    {{ $gatewayUrl := "https://andreas.dev.renku.ch/api" }}
+    {{ $gitlabUrl := "https://dev.renku.ch/gitlab" }}
+    {{ $jupyterhubUrl := "https://andreas.dev.renku.ch/jupyterhub" }}
+    [http]
+      [http.routers]
+        [http.routers.gateway]
+          entryPoints = ["http"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}auth`) || PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}graph`)"
+          Service = "gateway"
+
+        [http.routers.jupyterhub]
+          entryPoints = ["http"]
+          Middlewares = ["auth-jupyterhub", "common", "jupyterhub" ]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}jupyterhub`)"
+          Service = "jupyterhub"
+
+        [http.routers.notebooks]
+          entryPoints = ["http"]
+          Middlewares = ["auth-jupyterhub", "common", "notebooks"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}notebooks`)"
+          Service = "jupyterhub"
+
+        [http.routers.webhooks]
+          entryPoints = ["http"]
+          Middlewares = ["auth-gitlab", "common", "webhooks"]
+          Rule = "Path(`{{ .Values.gatewayServicePrefix | default "/api/" }}projects/{project-id}/graph/webhooks{endpoint:(.*)}`)"
+          Service = "webhooks"
+
+        [http.routers.graphstatus]
+          entryPoints = ["http"]
+          Middlewares = ["auth-gitlab", "common", "graphstatus"]
+          Rule = "Path(`{{ .Values.gatewayServicePrefix | default "/api/" }}projects/{project-id}/graph/status{endpoint:(.*)}`)"
+          Service = "webhooks"
+
+        [http.routers.gitlab]
+          entryPoints = ["http"]
+          Middlewares = ["auth-gitlab", "common", "gitlab"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}`)"
+          Service = "gitlab"
+
+      [http.middlewares]
+        [http.middlewares.common.chain]
+          {{- if .Values.development }}
+          middlewares = ["api", "noCookies", "development"]
+          {{- else }}
+          middlewares = ["api", "noCookies"]
+          {{- end }}
+
+        [http.middlewares.noCookies.headers]
+          [http.middlewares.noCookies.headers.CustomRequestHeaders]
+            Cookie = ""
+
+        [http.middlewares.api.StripPrefix]
+          prefixes = ["/api"]
+
+        [http.middlewares.development.headers]
+          isDevelopment = true
+
+        [http.middlewares.gitlab.AddPrefix]
+          prefix = "{{ .Values.global.gitlab.urlPrefix }}/api/v4"
+
+        [http.middlewares.jupyterhub.ReplacePathRegex]
+          regex = "^/jupyterhub/(.*)"
+          replacement = "/jupyterhub/hub/api/$1"
+
+        [http.middlewares.notebooks.ReplacePathRegex]
+          regex = "^/notebooks/(.*)"
+          replacement = "/jupyterhub/services/notebooks/$1"
+
+        [http.middlewares.auth-gitlab.forwardauth]
+          address = "http://{{ template "gateway.fullname" . }}-auth/?auth=gitlab"
+          trustForwardHeader = true
+          authResponseHeaders = ["Authorization"]
+
+        [http.middlewares.auth-jupyterhub.forwardauth]
+          address = "http://{{ template "gateway.fullname" . }}-auth/?auth=jupyterhub"
+          trustForwardHeader = true
+          authResponseHeaders = ["Authorization"]
+
+        [http.middlewares.webhooks.ReplacePathRegex]
+          regex = "^/projects/([^/]*)/graph/webhooks(.*)"
+          replacement = "/projects/$1/webhooks$2"
+
+        [http.middlewares.graphstatus.ReplacePathRegex]
+          regex = "^/projects/([^/]*)/graph(.*)"
+          replacement = "/projects/$1/events$2"
+
+      [http.services]
+        [http.services.gateway.LoadBalancer]
+          method = "drr"
+          [[http.services.gateway.LoadBalancer.servers]]
+            url = "http://{{ template "gateway.fullname" . }}-auth/"
+            weight = 1
+
+        [http.services.gitlab.LoadBalancer]
+          method = "drr"
+          [[http.services.gitlab.LoadBalancer.servers]]
+            url = {{ .Values.gitlabUrl | default (printf "%s://%s/gitlab" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
+            weight = 1
+
+        [http.services.jupyterhub.LoadBalancer]
+          method = "drr"
+          [[http.services.jupyterhub.LoadBalancer.servers]]
+            url = {{ .Values.jupyterhub.url | default (printf "%s://%s/jupyterhub" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
+            weight = 1
+
+        [http.services.webhooks.LoadBalancer]
+          method = "drr"
+          [[http.services.webhooks.LoadBalancer.servers]]
+            url = {{ .Values.graph.webhookService.hostname | default (printf "http://%s-graph-webhook-service" .Release.Name ) | quote }}
+            weight = 1

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -55,7 +55,7 @@ data:
 
         [http.routers.notebooks]
           entryPoints = ["http"]
-          Middlewares = ["auth-jupyterhub", "common", "notebooks"]
+          Middlewares = ["notebooks-ratelimit", "auth-jupyterhub", "common", "notebooks"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}notebooks`)"
           Service = "jupyterhub"
 
@@ -80,9 +80,9 @@ data:
       [http.middlewares]
         [http.middlewares.common.chain]
           {{- if .Values.development }}
-          middlewares = ["api", "noCookies", "development"]
+          middlewares = ["general-ratelimit", "api", "noCookies", "development"]
           {{- else }}
-          middlewares = ["api", "noCookies"]
+          middlewares = ["general-ratelimit", "api", "noCookies"]
           {{- end }}
 
         [http.middlewares.noCookies.headers]
@@ -123,6 +123,20 @@ data:
         [http.middlewares.graphstatus.ReplacePathRegex]
           regex = "^/projects/([^/]*)/graph(.*)"
           replacement = "/projects/$1/events$2"
+
+        [http.middlewares.general-ratelimit.ratelimit]
+          extractorfunc = "{{ .Values.rateLimits.general.extractorfunc }}"
+          [http.middlewares.general-ratelimit.ratelimit.rateset.rate0]
+            period = "{{ .Values.rateLimits.general.period }}"
+            average = {{ .Values.rateLimits.general.average }}
+            burst = {{ .Values.rateLimits.general.burst }}
+
+        [http.middlewares.notebooks-ratelimit.ratelimit]
+          extractorfunc = "{{ .Values.rateLimits.notebooks.extractorfunc }}"
+          [http.middlewares.notebooks-ratelimit.ratelimit.rateset.rate0]
+            period = "{{ .Values.rateLimits.notebooks.period }}"
+            average = {{ .Values.rateLimits.notebooks.average }}
+            burst = {{ .Values.rateLimits.notebooks.burst }}
 
       [http.services]
         [http.services.gateway.LoadBalancer]

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -37,6 +37,26 @@ replicaCount: 1
 ## implications and should never be done in a production setting.
 development: false
 
+## To protect the backend services from an excessive amount of API calls
+## issued by one client, one can enforce rate limits here. The limits apply
+## per UI client session (identified by the cookies). For an explanation of
+## the different values check out the rate limiting documentation of traefik
+## v2.0.
+rateLimits:
+  ## General rate limit, applies to all /api calls combined.
+  general:
+    extractorfunc: request.header.cookies
+    period: 10s
+    average: 20
+    burst: 100
+  ## Special rate limit for the notebooks service (/api/notebooks)
+  notebooks:
+    extractorfunc: request.header.cookies
+    period: 10s
+    average: 5
+    burst: 10
+
+
 ## Set to a custom GitLab URL if deployed manually
 # gitlabUrl:
 

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -69,7 +69,9 @@ jupyterhub:
 image:
   name: traefik
   repository: traefik
-  tag: 'v2.0'
+  # Specifically force the usage of alpha4 as it contains
+  # https://github.com/containous/traefik/commit/ef8894ef269e5e28d73e96c482d60162b898721a
+  tag: v2.0.0-alpha4
   pullPolicy: IfNotPresent
 
   ## Define the image for the auth middleware


### PR DESCRIPTION
- Restructure traefik configuration
- Introduce rate limits, make them configurable through chart values. The default chart values for the rate limits are 20 req per 10s (burstable up to 100 req / 10s) in general and 10 req per 3s (burstable up to 10 req / 10s) for the notebooks service. Violation of those limits will result in a `429 - too many requests` response.

---
The PR is currently deployed under https://andreas.dev.renku.ch