### PR TITLE
fix(charts): remove accidentally added helm variables

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -37,9 +37,6 @@ data:
       bufferingSize = 10
 
   rules.toml: |
-    {{ $gatewayUrl := "https://andreas.dev.renku.ch/api" }}
-    {{ $gitlabUrl := "https://dev.renku.ch/gitlab" }}
-    {{ $jupyterhubUrl := "https://andreas.dev.renku.ch/jupyterhub" }}
     [http]
       [http.routers]
         [http.routers.gateway]


### PR DESCRIPTION
These hardcoded helm variables accidentally added in the last PR were not used.