### PR TITLE
fix(charts): adjust notebooks rate limits

### DIFF
--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -54,7 +54,7 @@ rateLimits:
     extractorfunc: request.header.cookie
     period: 10s
     average: 5
-    burst: 10
+    burst: 30
 
 
 ## Set to a custom GitLab URL if deployed manually


### PR DESCRIPTION
When starting a new server, it's easy to hit the 10 requests per second burst threshold