### PR TITLE
fix(charts): re-adjust notebooks rate limits

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -52,7 +52,7 @@ data:
 
         [http.routers.notebooks]
           entryPoints = ["http"]
-          Middlewares = ["notebooks-ratelimit", "auth-jupyterhub", "common", "notebooks"]
+          Middlewares = ["auth-jupyterhub", "common", "notebooks"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}notebooks`)"
           Service = "jupyterhub"
 
@@ -127,13 +127,6 @@ data:
             period = "{{ .Values.rateLimits.general.period }}"
             average = {{ .Values.rateLimits.general.average }}
             burst = {{ .Values.rateLimits.general.burst }}
-
-        [http.middlewares.notebooks-ratelimit.ratelimit]
-          extractorfunc = "{{ .Values.rateLimits.notebooks.extractorfunc }}"
-          [http.middlewares.notebooks-ratelimit.ratelimit.rateset.rate0]
-            period = "{{ .Values.rateLimits.notebooks.period }}"
-            average = {{ .Values.rateLimits.notebooks.average }}
-            burst = {{ .Values.rateLimits.notebooks.burst }}
 
       [http.services]
         [http.services.gateway.LoadBalancer]

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -49,13 +49,6 @@ rateLimits:
     period: 10s
     average: 20
     burst: 100
-  ## Special rate limit for the notebooks service (/api/notebooks)
-  notebooks:
-    extractorfunc: request.header.cookie
-    period: 10s
-    average: 5
-    burst: 30
-
 
 ## Set to a custom GitLab URL if deployed manually
 # gitlabUrl:


### PR DESCRIPTION
We have recently raised the rate limits for requests to the notebooks service (#154) but it is occasionally reached when starting a new notebook with SwissDataScienceCenter/renku-ui#472 . Considering that SwissDataScienceCenter/renku-notebooks#177 has been merged, we can safely relax it a little bit more. 