### PR TITLE
feat: add content-based redirection for Renku entities

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -39,6 +39,18 @@ data:
   rules.toml: |
     [http]
       [http.routers]
+        [http.routers.apiRedirect]
+          entryPoints = ["http"]
+          Middlewares = ["apiRediredctEncodeSlash", "apiRedirect"]
+          Rule = "PathPrefix(`/entities`) && HeadersRegexp(`Accept`,`application/json`)"
+          Service = "default"
+
+        [http.routers.uiRedirect]
+          entryPoints = ["http"]
+          Middlewares = ["uiRedirect"]
+          Rule = "PathPrefix(`/entities`) && HeadersRegexp(`Accept`,`text/html`)"
+          Service = "default"
+
         [http.routers.gateway]
           entryPoints = ["http"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}auth`)"
@@ -87,6 +99,22 @@ data:
           Service = "core"
 
       [http.middlewares]
+
+        # We assume entity IDs which are URL-safe except <namespace>/<project-name>
+        # IDs (so all IDs with one forward-slash) for projets which we capture and
+        # URL-encode explicitly. Full URL-encoding is tricky with GO regexes.
+        [http.middlewares.apiRediredctEncodeSlash.redirectRegex]
+          regex = "http://(.*)/entities/([^/]*)/([^/]*)/(.*)"
+          replacement = "{{(include "gateway.protocol" .)}}://${1}/api/${2}/${3}%2F${4}"
+
+        [http.middlewares.apiRedirect.redirectRegex]
+          regex = "http://(.*)/entities/(.*)"
+          replacement = "{{(include "gateway.protocol" .)}}://${1}/api/${2}"
+
+        [http.middlewares.uiRedirect.redirectRegex]
+          regex = "http://(.*)/entities/(.*)"
+          replacement = "{{(include "gateway.protocol" .)}}://${1}/${2}"
+
         [http.middlewares.common.chain]
           {{- if .Values.development }}
           middlewares = ["general-ratelimit", "api", "noCookies", "development"]
@@ -190,4 +218,11 @@ data:
           passHostHeader = false
           [[http.services.core.LoadBalancer.servers]]
           url = {{ printf "http://%s" (include "core.fullname" .) | default (printf "http://%s-core" .Release.Name ) | quote }}
+            weight = 1
+
+        # We need a default backend, should never be hit
+        [http.services.default.LoadBalancer]
+          method = "drr"
+          [[http.services.default.LoadBalancer.servers]]
+          url = {{ printf "%s://%s" (include "gateway.protocol" .) .Values.global.renku.domain | quote }}
             weight = 1

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -86,6 +86,12 @@ data:
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}graphql`)"
           Service = "graphql"
 
+        [http.routers.datasets]
+          entryPoints = ["http"]
+          Middlewares = ["common", "knowledgeGraph"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}datasets`)"
+          Service = "knowledgeGraph"
+
         [http.routers.gitlab]
           entryPoints = ["http"]
           Middlewares = ["auth-gitlab", "common", "gitlab"]
@@ -170,6 +176,9 @@ data:
           regex = "/graphql"
           replacement = "/knowledge-graph/graphql"
 
+        [http.middlewares.knowledgeGraph.AddPrefix]
+          prefix = "/knowledge-graph"
+
         [http.middlewares.general-ratelimit.ratelimit]
           extractorfunc = "{{ .Values.rateLimits.general.extractorfunc }}"
           [http.middlewares.general-ratelimit.ratelimit.rateset.rate0]
@@ -210,6 +219,12 @@ data:
           method = "drr"
           passHostHeader = false
           [[http.services.graphql.LoadBalancer.servers]]
+          url = {{ printf "http://%s" (include "knowledgeGraph.fullname" .) | default (printf "http://%s-knowledge-graph" .Release.Name ) | quote }}
+            weight = 1
+
+        [http.services.knowledgeGraph.LoadBalancer]
+          method = "drr"
+          [[http.services.knowledgeGraph.LoadBalancer.servers]]
           url = {{ printf "http://%s" (include "knowledgeGraph.fullname" .) | default (printf "http://%s-knowledge-graph" .Release.Name ) | quote }}
             weight = 1
 

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -152,36 +152,42 @@ data:
       [http.services]
         [http.services.gateway.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.gateway.LoadBalancer.servers]]
             url = "http://{{ template "gateway.fullname" . }}-auth/"
             weight = 1
 
         [http.services.gitlab.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.gitlab.LoadBalancer.servers]]
             url = {{ .Values.gitlabUrl | default (printf "%s://%s/gitlab" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
             weight = 1
 
         [http.services.jupyterhub.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.jupyterhub.LoadBalancer.servers]]
             url = {{ .Values.jupyterhub.url | default (printf "%s://%s/jupyterhub" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
             weight = 1
 
         [http.services.webhooks.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.webhooks.LoadBalancer.servers]]
             url = {{ .Values.graph.webhookService.hostname | default (printf "http://%s-webhook-service" .Release.Name ) | quote }}
             weight = 1
 
         [http.services.graphql.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.graphql.LoadBalancer.servers]]
           url = {{ printf "http://%s" (include "knowledgeGraph.fullname" .) | default (printf "http://%s-knowledge-graph" .Release.Name ) | quote }}
             weight = 1
 
         [http.services.core.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.core.LoadBalancer.servers]]
           url = {{ printf "http://%s" (include "core.fullname" .) | default (printf "http://%s-core" .Release.Name ) | quote }}
             weight = 1

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -23,10 +23,10 @@ global:
     ## set by parent chart.
     domain: example.local
 
-    ## Set the Keycloak Realm name used by Renku here - the default 
-    ## value is "Renku" and is set on the application level. You may 
-    ## override this here if you are using an external Keycloak instance 
-    ## and want to use an existing realm. If Keycloak is deployed as a 
+    ## Set the Keycloak Realm name used by Renku here - the default
+    ## value is "Renku" and is set on the application level. You may
+    ## override this here if you are using an external Keycloak instance
+    ## and want to use an existing realm. If Keycloak is deployed as a
     ## part of Renku DO NOT change this value.
     # keycloak:
     #   realm: Renku
@@ -82,9 +82,7 @@ jupyterhub:
 image:
   name: traefik
   repository: traefik
-  # Specifically force the usage of alpha4 as it contains
-  # https://github.com/containous/traefik/commit/ef8894ef269e5e28d73e96c482d60162b898721a
-  tag: v2.0.0-alpha4
+  tag: 2.1.4
   pullPolicy: IfNotPresent
 
   ## Define the image for the auth middleware


### PR DESCRIPTION
closes #174.

Currently deployed under https://andreas.dev.renku.ch