### PR TITLE
chore: bump traefik version to v2.1.4

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -152,36 +152,42 @@ data:
       [http.services]
         [http.services.gateway.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.gateway.LoadBalancer.servers]]
             url = "http://{{ template "gateway.fullname" . }}-auth/"
             weight = 1
 
         [http.services.gitlab.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.gitlab.LoadBalancer.servers]]
             url = {{ .Values.gitlabUrl | default (printf "%s://%s/gitlab" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
             weight = 1
 
         [http.services.jupyterhub.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.jupyterhub.LoadBalancer.servers]]
             url = {{ .Values.jupyterhub.url | default (printf "%s://%s/jupyterhub" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
             weight = 1
 
         [http.services.webhooks.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.webhooks.LoadBalancer.servers]]
             url = {{ .Values.graph.webhookService.hostname | default (printf "http://%s-webhook-service" .Release.Name ) | quote }}
             weight = 1
 
         [http.services.graphql.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.graphql.LoadBalancer.servers]]
           url = {{ printf "http://%s" (include "knowledgeGraph.fullname" .) | default (printf "http://%s-knowledge-graph" .Release.Name ) | quote }}
             weight = 1
 
         [http.services.core.LoadBalancer]
           method = "drr"
+          passHostHeader = false
           [[http.services.core.LoadBalancer.servers]]
           url = {{ printf "http://%s" (include "core.fullname" .) | default (printf "http://%s-core" .Release.Name ) | quote }}
             weight = 1

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -23,10 +23,10 @@ global:
     ## set by parent chart.
     domain: example.local
 
-    ## Set the Keycloak Realm name used by Renku here - the default 
-    ## value is "Renku" and is set on the application level. You may 
-    ## override this here if you are using an external Keycloak instance 
-    ## and want to use an existing realm. If Keycloak is deployed as a 
+    ## Set the Keycloak Realm name used by Renku here - the default
+    ## value is "Renku" and is set on the application level. You may
+    ## override this here if you are using an external Keycloak instance
+    ## and want to use an existing realm. If Keycloak is deployed as a
     ## part of Renku DO NOT change this value.
     # keycloak:
     #   realm: Renku
@@ -82,9 +82,7 @@ jupyterhub:
 image:
   name: traefik
   repository: traefik
-  # Specifically force the usage of alpha4 as it contains
-  # https://github.com/containous/traefik/commit/ef8894ef269e5e28d73e96c482d60162b898721a
-  tag: v2.0.0-alpha4
+  tag: 2.1.4
   pullPolicy: IfNotPresent
 
   ## Define the image for the auth middleware


### PR DESCRIPTION
Deployed (together with #188) in https://andreas.dev.renku.ch

~Bumping to v2.0 only instead of v2.1 as tests (on a shaky network though) suggested some problems with v2.1. Leaving the upgrade to v2.1 (including some further tests) for later.~

Problem identified (https://github.com/containous/traefik/pull/5516) and fixed by explicitly turning host header forwarding off.