### PR TITLE
feat: enable anonymous jupyterhub sessions

### DIFF
--- a/app/auth/jupyterhub_auth.py
+++ b/app/auth/jupyterhub_auth.py
@@ -24,7 +24,8 @@ from urllib.parse import parse_qs, urlencode, urljoin
 import jwt
 import requests
 from oic import rndstr
-from quart import Blueprint, redirect, request, session, url_for, current_app
+from quart import (Blueprint, current_app, redirect, request,
+    Response, session, url_for)
 
 from .web import JWT_ALGORITHM, get_key_for_user
 
@@ -87,6 +88,27 @@ def login():
     login_url = "{}?{}".format(url, urlencode(args))
     response = current_app.make_response(redirect(login_url))
     return response
+
+
+@blueprint.route('/login-tmp')
+def login_tmp():
+    """Redirection creating an anonymous (temporary) Jupyterhub session."""
+
+    if not current_app.config['ANONYMOUS_SESSIONS_ENABLED']:
+        return Response(
+            'Anonymous notebooks sessions are disabled',
+            status=404
+        )
+
+    args = {'redirect_url': request.args['redirect_url']}
+
+    full_url = "{}{}?{}".format(
+        current_app.config['JUPYTERHUB_TMP_URL'],
+        '/services/notebooks/login-tmp',
+        urlencode(args)
+        )
+
+    return current_app.make_response(redirect(full_url))
 
 
 @blueprint.route('/token')

--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,10 @@ import sys
 import warnings
 
 
+ANONYMOUS_SESSIONS_ENABLED = os.environ.get(
+    'ANONYMOUS_SESSIONS_ENABLED', 'false'
+) == 'true'
+
 HOST_NAME = os.environ.get('HOST_NAME', 'http://gateway.renku.build')
 
 if 'GATEWAY_SECRET_KEY' not in os.environ and "pytest" not in sys.modules:
@@ -54,6 +58,9 @@ if not GITLAB_CLIENT_SECRET:
 JUPYTERHUB_URL = os.environ.get(
         'JUPYTERHUB_URL', '{}/jupyterhub'.format(HOST_NAME)
     )
+if ANONYMOUS_SESSIONS_ENABLED:
+    JUPYTERHUB_TMP_URL = '{}-tmp'.format(JUPYTERHUB_URL)
+
 JUPYTERHUB_CLIENT_ID = os.environ.get(
         'JUPYTERHUB_CLIENT_ID', 'gateway'
     )

--- a/helm-chart/renku-gateway/Chart.yaml
+++ b/helm-chart/renku-gateway/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '2.0'
 description: A Helm chart for the Renku gateway
 name: renku-gateway
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.7.0
+version: 0.7.1

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -27,7 +27,6 @@ data:
     [providers]
       [providers.file]
         directory = "/config"
-        filename = "rules.toml"
 
     [entrypoints]
       [entrypoints.http]

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -62,11 +62,13 @@ data:
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}jupyterhub`)"
           Service = "jupyterhub"
 
+{{ if eq .Values.global.anonymousSessions.enabled false }}
         [http.routers.notebooks]
           entryPoints = ["http"]
           Middlewares = ["auth-jupyterhub", "common", "notebooks"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}notebooks`)"
           Service = "jupyterhub"
+{{ end }}
 
         [http.routers.webhooks]
           entryPoints = ["http"]
@@ -93,6 +95,10 @@ data:
           Service = "knowledgeGraph"
 
         [http.routers.gitlab]
+          # Currently gitlab acts as fallback backend service, we
+          # therefore fix the priority of this router to the lowest
+          # possible value.
+          priority = 1
           entryPoints = ["http"]
           Middlewares = ["auth-gitlab", "common", "gitlab"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}`)"
@@ -121,12 +127,15 @@ data:
           regex = "http://(.*)/entities/(.*)"
           replacement = "{{(include "gateway.protocol" .)}}://${1}/${2}"
 
-        [http.middlewares.common.chain]
+        [http.middlewares.commonWithCookie.chain]
           {{- if .Values.development }}
-          middlewares = ["general-ratelimit", "api", "noCookies", "development"]
+          middlewares = ["general-ratelimit", "api", "development"]
           {{- else }}
-          middlewares = ["general-ratelimit", "api", "noCookies"]
+          middlewares = ["general-ratelimit", "api"]
           {{- end }}
+
+        [http.middlewares.common.chain]
+          middlewares = ["noCookies", "commonWithCookie"]
 
         [http.middlewares.noCookies.headers]
           [http.middlewares.noCookies.headers.CustomRequestHeaders]
@@ -145,9 +154,11 @@ data:
           regex = "^/jupyterhub/(.*)"
           replacement = "/jupyterhub/hub/api/$1"
 
+{{ if eq .Values.global.anonymousSessions.enabled false }}
         [http.middlewares.notebooks.ReplacePathRegex]
           regex = "^/notebooks/(.*)"
           replacement = "/jupyterhub/services/notebooks/$1"
+{{ end }}
 
         [http.middlewares.auth-gitlab.forwardauth]
           address = "http://{{ template "gateway.fullname" . }}-auth/?auth=gitlab"
@@ -241,3 +252,74 @@ data:
           [[http.services.default.LoadBalancer.servers]]
           url = {{ printf "%s://%s" (include "gateway.protocol" .) .Values.global.renku.domain | quote }}
             weight = 1
+
+{{ if .Values.global.anonymousSessions.enabled }}
+  rules-tmp.toml: |
+    [http]
+      [http.routers]
+
+        # What we do here is equivalent to using a second traefik instance in front
+        # of the two notebook services.
+        # - If the regular jupyterhub-auth finds a JH oauth token, we use
+        #   it and forward to the normal notebook service.
+        # - Otherwise we use the notebooks-tmp service.
+
+
+        # Note that routers are applied in the order of their priority,
+        # where the priority is derived from the length of the rule
+        # (longer -> more specific -> higher priority). This priority can be
+        # explicitly overwritten.
+
+        [http.routers.notebooksFirstPass]
+          priority=1001
+          entryPoints = ["http"]
+          Middlewares = ["auth-jupyterhub", "secondPassPath"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}notebooks`)"
+          Service = "notebooksSecondPass"
+
+        [http.routers.notebooksSecondPassTmp]
+          priority=1002
+          entryPoints = ["http"]
+          Middlewares = ["commonWithCookie", "notebooksTmp"]
+          Rule = "PathPrefix(`/notebooks-second-pass`)"
+          Service = "jupyterhubTmp"
+
+        [http.routers.notebooksSecondPassRegular]
+          priority=1003
+          entryPoints = ["http"]
+          Middlewares = ["common", "notebooks"]
+          Rule = "PathPrefix(`/notebooks-second-pass`) && HeadersRegexp(`Authorization`, `token`)"
+          Service = "jupyterhub"
+
+      [http.middlewares]
+
+        [http.middlewares.secondPassPath.ReplacePathRegex]
+          regex = "/api/notebooks/(.*)"
+          replacement = "/notebooks-second-pass/$1"
+
+        [http.middlewares.notebooks.ReplacePathRegex]
+          regex = "^/notebooks-second-pass/(.*)"
+          replacement = "/jupyterhub/services/notebooks/$1"
+
+        [http.middlewares.notebooksTmp.ReplacePathRegex]
+          regex = "^/notebooks-second-pass/(.*)"
+          replacement = "/jupyterhub-tmp/services/notebooks/$1"
+
+
+      [http.services]
+
+        [http.services.notebooksSecondPass.LoadBalancer]
+          method = "drr"
+          passHostHeader = false
+          [[http.services.notebooksSecondPass.LoadBalancer.servers]]
+            url = "http://{{ template "gateway.fullname" . }}"
+            weight = 1
+
+
+        [http.services.jupyterhubTmp.LoadBalancer]
+          method = "drr"
+          passHostHeader = false
+          [[http.services.jupyterhubTmp.LoadBalancer.servers]]
+            url = {{ .Values.jupyterhub.tmpUrl | default (printf "%s://%s/jupyterhub-tmp" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
+            weight = 1
+{{ end }}

--- a/helm-chart/renku-gateway/templates/deployment.yaml
+++ b/helm-chart/renku-gateway/templates/deployment.yaml
@@ -155,6 +155,10 @@ spec:
               value: {{ required "Please specify a password for the SPARQL endpoint user." .Values.graph.sparql.password | quote }}
             - name: WEBHOOK_SERVICE_HOSTNAME
               value: {{ .Values.graph.webhookService.hostname | default (printf "http://%s-graph-webhook-service" .Release.Name ) | quote }}
+            {{ if .Values.global.anonymousSessions.enabled }}
+            - name: ANONYMOUS_SESSIONS_ENABLED
+              value: "true"
+            {{ end }}
           livenessProbe:
             httpGet:
               path: /health

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -31,6 +31,12 @@ global:
     # keycloak:
     #   realm: Renku
 
+  anonymousSessions:
+    ## Set this to true (probably in the parent chart) when deploying
+    ## a second notebook service (incl. Jupyterhub) for anonymous notebook
+    ## sessions.
+    enabled: false
+
 replicaCount: 1
 
 ## Set to true to enable the developement mode. This has negative security
@@ -78,6 +84,10 @@ jupyterhub:
   ## Client secret, this should match the api_token
   ## use `openssl rand -hex 32`
   clientSecret:
+
+  ## the url of a potential secondary jupyterhub
+  ## deployment for anonymous sessions
+  # tmpUrl:
 
 image:
   name: traefik


### PR DESCRIPTION
- Create a login route which triggers an anonymous session
  with the secondary Jupyterhub instance handling temporary sessions.
  Closes #193 

- Add rules to the gateway to separate traffic between
  the primary and the secondary notebooks service.
  Closes #195 