### PR TITLE
Expose `/api/graph/queries` through the gateway

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -93,6 +93,12 @@ data:
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}datasets`)"
           Service = "knowledgeGraph"
 
+        [http.routers.graphQueries]
+          entryPoints = ["http"]
+          Middlewares = ["auth-gitlab", "common", "knowledgeGraph"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}graph/queries`)"
+          Service = "knowledgeGraph"
+
         [http.routers.gitlab]
           # Currently gitlab acts as fallback backend service, we
           # therefore fix the priority of this router to the lowest


### PR DESCRIPTION
We forward the

```
/api/graph/queries -> /knowledge-graph/queries
```
while adding `Authorization: Bearer <gitlab-user-token>` to the header.