### PR TITLE
fix: change logout method to POST

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -92,3 +92,5 @@ if not OIDC_CLIENT_SECRET:
     )
 
 SERVICE_PREFIX = os.environ.get("GATEWAY_SERVICE_PREFIX", "/")
+
+OLD_GITLAB_LOGOUT = os.environ.get("OLD_GITLAB_LOGOUT", "") == "true"

--- a/app/templates/gitlab_logout.html
+++ b/app/templates/gitlab_logout.html
@@ -1,0 +1,34 @@
+<!-- # Copyright 2018-2020 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License. -->
+<!DOCTYPE html>
+<html lang="en" >
+    <head>
+        <title>GitLab - logout</title>
+    </head>
+
+    <body>
+        <p>Logging you out from GitLab... </p>
+        <form
+            name="logout"
+            action="{{logout_url}}"
+            method="post">
+        </form>
+
+        <script type="text/javascript">
+            document.logout.submit();
+        </script>
+    </body>
+</html>

--- a/helm-chart/renku-gateway/Chart.yaml
+++ b/helm-chart/renku-gateway/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '2.0'
 description: A Helm chart for the Renku gateway
 name: renku-gateway
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.7.1
+version: 0.8.0

--- a/helm-chart/renku-gateway/templates/deployment.yaml
+++ b/helm-chart/renku-gateway/templates/deployment.yaml
@@ -147,6 +147,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "gateway.fullname" . }}
                   key: oidcClientSecret
+            - name: OLD_GITLAB_LOGOUT
+              value: {{ .Values.oldGitLabLogout | quote }}
             - name: SPARQL_ENDPOINT
               value: {{ .Values.graph.sparql.endpoint | default (printf "http://%s-jena:3030/%s/sparql" .Release.Name .Release.Namespace ) | quote }}
             - name: SPARQL_USERNAME

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -154,3 +154,9 @@ graph:
     ## can be reached (internally). This will default to
     ## http://<release-name>-graph-webhook-service
     hostname:
+
+# GitLab has introduced a new logout behavior in 12.7.0
+# which was initially broken and fixed in 12.9.0.
+# Set this to 'true' for versions < 12.7.0, leave it to
+# 'false' for versions >= 12.9.0.
+oldGitLabLogout: false


### PR DESCRIPTION
GitLab 12.7.0 prevented triggering GitLab logout from outside GitLab, 12.9.0 brought it back. However, a POST request is necessary now. 

My(@ableuler) suggestion is actually to keep this PR open for 2-3 months until more people will be ready to migrate their GitLab instance to `>=12.9.0`.