### PR TITLE
Remove dependency from renku chart

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -229,20 +229,20 @@ data:
           method = "drr"
           passHostHeader = false
           [[http.services.graphql.LoadBalancer.servers]]
-          url = {{ printf "http://%s" (include "knowledgeGraph.fullname" .) | default (printf "http://%s-knowledge-graph" .Release.Name ) | quote }}
+          url = {{ .Values.graph.knowledgeGraph.hostname | default (printf "http://%s-knowledge-graph" .Release.Name ) | quote }}
             weight = 1
 
         [http.services.knowledgeGraph.LoadBalancer]
           method = "drr"
           [[http.services.knowledgeGraph.LoadBalancer.servers]]
-          url = {{ printf "http://%s" (include "knowledgeGraph.fullname" .) | default (printf "http://%s-knowledge-graph" .Release.Name ) | quote }}
+          url = {{ .Values.graph.knowledgeGraph.hostname | default (printf "http://%s-knowledge-graph" .Release.Name ) | quote }}
             weight = 1
 
         [http.services.core.LoadBalancer]
           method = "drr"
           passHostHeader = false
           [[http.services.core.LoadBalancer.servers]]
-          url = {{ printf "http://%s" (include "core.fullname" .) | default (printf "http://%s-core" .Release.Name ) | quote }}
+          url = {{ .Values.core.hostname | default (printf "http://%s-core" .Release.Name ) | quote }}
             weight = 1
 
         # We need a default backend, should never be hit

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -152,8 +152,19 @@ graph:
   webhookService:
     ## Set the hostname under which the webhook service
     ## can be reached (internally). This will default to
-    ## http://<release-name>-graph-webhook-service
+    ## http://<release-name>-webhook-service
     hostname:
+  knowledgeGraph:
+    ## Set the hostname under which the webhook service
+    ## can be reached (internally). This will default to
+    ## http://<release-name>-knowledge-graph
+    hostname:
+
+core:
+  ## Set the hostname under which the core service
+  ## can be reached (internally). This will default to
+  ## http://<release-name>-core
+  hostname:
 
 # GitLab has introduced a new logout behavior in 12.7.0
 # which was initially broken and fixed in 12.9.0.


### PR DESCRIPTION
This PR removes the references to `core.fullname` and `knowledgeGraph.fullname` which are defined in the main renku chart. This allows the gateway chart to be rendered independently.

Closes #203.