### PR TITLE
chore: add direct route to gitlab to use undocumented apis

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -93,13 +93,20 @@ data:
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}datasets`)"
           Service = "knowledgeGraph"
 
+        [http.routers.direct]
+          # This is to access undocumented APIs in GitLab
+          entryPoints = ["http"]
+          Middlewares = ["auth-gitlab", "direct", "gitlabOnly"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}direct/`)"
+          Service = "gitlab"
+
         [http.routers.gitlab]
           # Currently gitlab acts as fallback backend service, we
           # therefore fix the priority of this router to the lowest
           # possible value.
           priority = 1
           entryPoints = ["http"]
-          Middlewares = ["auth-gitlab", "common", "gitlab"]
+          Middlewares = ["auth-gitlab", "common", "gitlabApi", "gitlabOnly"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}`)"
           Service = "gitlab"
 
@@ -146,8 +153,11 @@ data:
         [http.middlewares.development.headers]
           isDevelopment = true
 
-        [http.middlewares.gitlab.AddPrefix]
-          prefix = "{{ .Values.global.gitlab.urlPrefix }}/api/v4"
+        [http.middlewares.gitlabOnly.AddPrefix]
+          prefix = "{{ .Values.global.gitlab.urlPrefix }}"
+
+        [http.middlewares.gitlabApi.AddPrefix]
+          prefix = "/api/v4"
 
         [http.middlewares.jupyterhub.ReplacePathRegex]
           regex = "^/jupyterhub/(.*)"
@@ -188,6 +198,10 @@ data:
 
         [http.middlewares.knowledgeGraph.AddPrefix]
           prefix = "/knowledge-graph"
+
+        [http.middlewares.direct.ReplacePathRegex]
+          regex = "^/api/direct/(.*)"
+          replacement = "/$1"
 
         [http.middlewares.general-ratelimit.ratelimit]
           extractorfunc = "{{ .Values.rateLimits.general.extractorfunc }}"

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -96,7 +96,7 @@ data:
         [http.routers.direct]
           # This is to access undocumented APIs in GitLab
           entryPoints = ["http"]
-          Middlewares = ["auth-gitlab", "direct", "gitlabOnly"]
+          Middlewares = ["direct", "gitlabOnly"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}direct/`)"
           Service = "gitlab"
 


### PR DESCRIPTION
In SwissDataScienceCenter/renku-ui#905 we are going to use an undocumented API from GitLab, requiring to query directly `/gitlab` instead of `/gitlab/api/v4`.

This PR adds routing for `/api/direct/` to allow that interaction. It's necessary to split the "gitlab" middleware because it's not possible to have 2 `AddPrefix` middlewares where one adds a substring of the other.

P.S.
As a reference, this is the error we would get if we didn't split the middleware

```
time="2020-07-20T14:02:58Z" level=error msg="cannot create middleware: multi-types middleware not supported, consider declaring two different pieces of middleware instead" entryPointName=http routerName=direct@file
```

And this is an example of how the `AddPrefix` works with an old "gitlab" URL and a new "direct" URL
```
# gitlab
time="2020-07-20T14:26:07Z" level=debug msg="URL.Path is now /api/v4/projects/520/issues/1/notes (was /projects/520/issues/1/notes)." middlewareName=gitlabApi@file middlewareType=AddPrefix
time="2020-07-20T14:26:07Z" level=debug msg="URL.Path is now /gitlab/api/v4/projects/520/issues/1/notes (was /api/v4/projects/520/issues/1/notes)." middlewareType=AddPrefix middlewareName=gitlabOnly@file

# direct
time="2020-07-20T14:26:09Z" level=debug msg="URL.Path is now /gitlab/noemail/scratch-project/-/issues/1/discussions (was /noemail/scratch-project/-/issues/1/discussions)." middlewareName=gitlabOnly@file middlewareType=AddPrefix
```


