### PR TITLE
fix: avoid crash on fullname non-latin-1 chars

### DIFF
--- a/app/auth/renku_auth.py
+++ b/app/auth/renku_auth.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """Add the headers for the Renku core service."""
 
+import base64
 import re
 
 from flask import current_app
@@ -46,7 +47,9 @@ class RenkuCoreAuthHeaders:
             access_token_dict = decode_keycloak_jwt(access_token.encode())
             headers["Renku-user-id"] = access_token_dict["sub"]
             headers["Renku-user-email"] = access_token_dict["email"]
-            headers["Renku-user-fullname"] = access_token_dict["name"]
+            headers["Renku-user-fullname"] = str(
+                base64.encodebytes(access_token_dict["name"].encode())
+            )
 
         else:
             pass


### PR DESCRIPTION
Very minimalistic fix for #252
The `Renku-user-fullname` gets encoded to base64 and sent with the `b` prexif (E.G. `"b'TG9yZW7FoW8gQ2F2YXp6aQ==\\n'"`). This (apparenty) results in automatic decoding from the receiving party.

We should switch to a more robust solution, like the other one suggested in #252