### PR TITLE
chore: move to github native dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "dependabot-updates"


### PR DESCRIPTION
~Together with merging this PR, the `dependabot preview` app should be deactivated for this repo~, see https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/.

We can merge this PR and see if it will result in dependency update PRs to the dedicated `dependabot-updates` branch. The idea would be to have auto-updates to a specific persistent branch and merge this branch into master occasionally.