### PR TITLE
feat(auth): pass on KC id token to core service

### DIFF
--- a/app/auth/gitlab_auth.py
+++ b/app/auth/gitlab_auth.py
@@ -82,7 +82,7 @@ class GitlabUserToken:
         return headers
 
 
-SCOPES = ["openid", "api", "read_user", "read_repository"]
+SCOPE = ["openid", "api", "read_user", "read_repository"]
 
 
 @blueprint.route("/login")
@@ -96,7 +96,7 @@ def login():
         provider_app,
         urljoin(current_app.config["HOST_NAME"], url_for("gitlab_auth.token")),
         GL_SUFFIX,
-        SCOPES,
+        SCOPE,
     )
 
 

--- a/app/auth/oauth_client.py
+++ b/app/auth/oauth_client.py
@@ -38,7 +38,7 @@ class RenkuWebApplicationClient(WebApplicationClient):
         self,
         *args,
         provider_app=None,
-        scopes=None,
+        scope=None,
         max_lifetime=None,
         _expires_at=None,
         **kwargs
@@ -48,7 +48,7 @@ class RenkuWebApplicationClient(WebApplicationClient):
             provider_app, OAuthProviderApp
         ), "provider_app property must be instance of OAuthProviderApp class"
         self.provider_app = provider_app
-        self.scopes = scopes
+        self.scope = scope
         self.max_lifetime = max_lifetime
         self._expires_at = _expires_at
 
@@ -67,7 +67,6 @@ class RenkuWebApplicationClient(WebApplicationClient):
             authorization_response=authorization_response,
             client_secret=self.provider_app.client_secret,
             client_id=self.provider_app.client_id,
-            scopes=self.scopes,
             include_client_id=True,
             **kwargs
         )
@@ -101,7 +100,7 @@ class RenkuWebApplicationClient(WebApplicationClient):
             "access_token",
             "refresh_token",
             "token",
-            "scopes",
+            "scope",
             "state",
             "code",
             "redirect_url",

--- a/app/auth/renku_auth.py
+++ b/app/auth/renku_auth.py
@@ -24,6 +24,7 @@ from flask import current_app
 
 from .utils import decode_keycloak_jwt, get_redis_key_from_token
 from .gitlab_auth import GL_SUFFIX
+from .web import KC_SUFFIX
 
 
 # TODO: We're using a class here only to have a uniform interface
@@ -38,6 +39,11 @@ class RenkuCoreAuthHeaders:
         )
         if m:
             access_token = m.group("token")
+
+            keycloak_oidc_client = current_app.store.get_oauth_client(
+                get_redis_key_from_token(access_token, key_suffix=KC_SUFFIX)
+            )
+            headers["Renku-user-id-token"] = keycloak_oidc_client.token["id_token"]
 
             gitlab_oauth_client = current_app.store.get_oauth_client(
                 get_redis_key_from_token(access_token, key_suffix=GL_SUFFIX)

--- a/app/auth/renku_auth.py
+++ b/app/auth/renku_auth.py
@@ -52,6 +52,9 @@ class RenkuCoreAuthHeaders:
                 gitlab_oauth_client.access_token
             )
 
+            # TODO: The subsequent information is now included in the JWT sent in the
+            # TODO: "Renku-User" header. It can be removed once the core-service
+            # TODO: relies on the new header.
             access_token_dict = decode_keycloak_jwt(access_token.encode())
             headers["Renku-user-id"] = access_token_dict["sub"]
             headers["Renku-user-email"] = b64encode(access_token_dict["email"].encode())

--- a/app/auth/renku_auth.py
+++ b/app/auth/renku_auth.py
@@ -43,7 +43,7 @@ class RenkuCoreAuthHeaders:
             keycloak_oidc_client = current_app.store.get_oauth_client(
                 get_redis_key_from_token(access_token, key_suffix=KC_SUFFIX)
             )
-            headers["Renku-user-id-token"] = keycloak_oidc_client.token["id_token"]
+            headers["Renku-User"] = keycloak_oidc_client.token["id_token"]
 
             gitlab_oauth_client = current_app.store.get_oauth_client(
                 get_redis_key_from_token(access_token, key_suffix=GL_SUFFIX)

--- a/app/auth/utils.py
+++ b/app/auth/utils.py
@@ -66,12 +66,12 @@ def get_redis_key_from_token(token, key_suffix=""):
     return _get_redis_key(decoded_token["sub"], key_suffix=key_suffix)
 
 
-def handle_login_request(provider_app, redirect_path, key_suffix, scopes):
+def handle_login_request(provider_app, redirect_path, key_suffix, scope):
     """Logic to handle the login requests, avoids duplication"""
     oauth_client = RenkuWebApplicationClient(
         provider_app=provider_app,
         redirect_url=urljoin(current_app.config["HOST_NAME"], redirect_path),
-        scopes=scopes,
+        scope=scope,
         max_lifetime=current_app.config["MAX_ACCESS_TOKEN_LIFETIME"],
     )
     authorization_url = oauth_client.get_authorization_url()

--- a/app/auth/web.py
+++ b/app/auth/web.py
@@ -43,7 +43,7 @@ from .utils import (
 blueprint = Blueprint("web_auth", __name__, url_prefix="/auth")
 
 KC_SUFFIX = "kc_oidc_client"
-SCOPES = ["openid"]
+SCOPE = ["openid"]
 
 
 def get_valid_token(headers):
@@ -134,7 +134,7 @@ def login():
         provider_app,
         urljoin(current_app.config["HOST_NAME"], url_for("web_auth.token")),
         KC_SUFFIX,
-        SCOPES,
+        SCOPE,
     )
 
 


### PR DESCRIPTION
This PR fixes obtaining the ID token from keycloak during login by making sure the defined scope is picked up by oauthlib (use `scope` instead of `scopes`) and ads the id token to a request which is forwarded to the core service in the custom header field `"Renku-User"` .

The original header fields are left there for backwards compatibility until the core service has adapted.

Closes #252