### PR TITLE
fix: adjust the time buffer in the token expiration date check function

### DIFF
--- a/app/auth/oauth_client.py
+++ b/app/auth/oauth_client.py
@@ -134,4 +134,4 @@ class RenkuWebApplicationClient(WebApplicationClient):
 
     def expires_soon(self):
         """Check if the client instance expires soon."""
-        return self._expires_at and self._expires_at < time.time() - 5
+        return self._expires_at and self._expires_at < time.time() + 5


### PR DESCRIPTION
While trying to address #267 , I found a bug in the function checking the token expiration date.
This is very likely the reason for the unnecessary re-login triggered on the UI that happens frequently when polling a specific API for a long time, and occasionally in other situations.

***How to test***
This is a bit tricky. The easiest way is lowering the access token lifespan in your dev renkulab deplyoment to 1 minute (see the image below).
Then open any of your projects and go to the environment page, so that the `/servers` API will be invoked every ~3 seconds. Without this PR, the UI will trigger a full login and refresh every minute. Running this PR (thorugh telepresence or using the gateway-auth image `lorenzocavazzitech/renku-gateway:0.9.0-0a593a8`) the token should refresh automatically in the backend without any side-effect in the UI -- and totally trasparent for the user.

![Expl_token](https://user-images.githubusercontent.com/43481553/95203748-76617080-07e3-11eb-9217-5b4a3f189d5b.png)
