### PR TITLE
docs: fix vscode debug command

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -39,6 +39,7 @@ from .auth import gitlab_auth, jupyterhub_auth, web
 from .auth.oauth_redis import OAuthRedis
 
 # Wait for the VS Code debugger to attach if requested
+# TODO: try using debugpy instead of ptvsd to avoid noreload limitations
 VSCODE_DEBUG = os.environ.get("VSCODE_DEBUG") == "1"
 if VSCODE_DEBUG:
     import ptvsd

--- a/run-telepresence.sh
+++ b/run-telepresence.sh
@@ -60,7 +60,7 @@ FLASK_APP=app:app \
 HOST_NAME=\$HOST_NAME \
 VSCODE_DEBUG=1 \
 OAUTHLIB_INSECURE_TRANSPORT=1 \
-${FLASK_EXECUTABLE} run"
+${FLASK_EXECUTABLE} run --no-reload"
 echo "================================================================================================================="
 
 


### PR DESCRIPTION
The previous command to attach the VScode debugger didn't work because flask starts multiple sub-processes.
The `--no-reload` flag is the easiest fix, at the cost of dropping the auto-refresh when the code is changed. There may be other better solutions to explore (e.g. `debugpy`,  but I didn't manage to debug properly with that).