### PR TITLE
return verbose errors on token validation exceptions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -180,7 +180,7 @@ def auth():
             f"Error while authenticating request, unknown. Target: {auth_arg}",
             exc_info=True,
         )
-        message = {"error": "authentication", "payload": "unknown", "target": auth_arg}
+        message = {"error": "authentication", "message": "unknown", "target": auth_arg}
         return Response(json.dumps(message), status=401)
 
     return Response(json.dumps("Up and running"), headers=headers, status=200,)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -148,27 +148,27 @@ def auth():
     except jwt.ExpiredSignatureError:
         current_app.logger.warning(
             f"Error while authenticating request, token expired. Target: {auth_arg}",
-            exc_info=True
+            exc_info=True,
         )
         message = {
             "error": "authentication",
             "message": "token expired",
-            "target": auth_arg
+            "target": auth_arg,
         }
         return Response(json.dumps(message), status=401)
     except AttributeError as error:
-        if ("access_token" in str(error)):
+        if "access_token" in str(error):
             current_app.logger.warning(
                 (
                     "Error while authenticating request, can't "
                     f"refresh access token. Target: {auth_arg}"
                 ),
-                exc_info=True
+                exc_info=True,
             )
             message = {
                 "error": "authentication",
                 "payload": "can't refresh access token",
-                "target": auth_arg
+                "target": auth_arg,
             }
             return Response(json.dumps(message), status=401)
         raise
@@ -177,16 +177,16 @@ def auth():
     except:  # noqa
         current_app.logger.warning(
             f"Error while authenticating request, unknown. Target: {auth_arg}",
-            exc_info=True
+            exc_info=True,
         )
-        message = {
-            "error": "authentication",
-            "payload": "unknown",
-            "target": auth_arg
-        }
+        message = {"error": "authentication", "payload": "unknown", "target": auth_arg}
         return Response(json.dumps(message), status=401)
 
-    return Response(json.dumps("Up and running"), headers=headers, status=200,)
+    return Response(
+        json.dumps("Up and running"),
+        headers=headers,
+        status=200,
+    )
 
 
 @app.route("/health", methods=["GET"])
@@ -203,7 +203,8 @@ def _join_url_prefix(*parts):
 
 for blueprint in blueprints:
     app.register_blueprint(
-        blueprint, url_prefix=_join_url_prefix(url_prefix, blueprint.url_prefix),
+        blueprint,
+        url_prefix=_join_url_prefix(url_prefix, blueprint.url_prefix),
     )
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -168,7 +168,7 @@ def auth():
             )
             message = {
                 "error": "authentication",
-                "payload": "can't refresh access token",
+                "message": "can't refresh access token",
                 "target": auth_arg,
             }
             return Response(json.dumps(message), status=401)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -182,11 +182,7 @@ def auth():
         message = {"error": "authentication", "payload": "unknown", "target": auth_arg}
         return Response(json.dumps(message), status=401)
 
-    return Response(
-        json.dumps("Up and running"),
-        headers=headers,
-        status=200,
-    )
+    return Response(json.dumps("Up and running"), headers=headers, status=200,)
 
 
 @app.route("/health", methods=["GET"])
@@ -203,8 +199,7 @@ def _join_url_prefix(*parts):
 
 for blueprint in blueprints:
     app.register_blueprint(
-        blueprint,
-        url_prefix=_join_url_prefix(url_prefix, blueprint.url_prefix),
+        blueprint, url_prefix=_join_url_prefix(url_prefix, blueprint.url_prefix),
     )
 
 


### PR DESCRIPTION
This will
* Provide extra content to the UI when sending a 401 error related to expired/invalid tokens
* Handle an expected exception without logging the corresponding error
 ```
[2020-10-12 09:41:23,824] INFO in oauth_redis: Refreshing cache_656bba26-0863-4e12-9fbc-ec0f0e79a4e1_kc_oidc_client
[2020-10-12 09:41:23,970] WARNING in oauth_redis: Error refreshing tokens: invalid_grant Clearing client from redis.
[2020-10-12 09:41:23,975] WARNING in __init__: Error while authenticating request
Traceback (most recent call last):
File "/code/app/__init__.py", line 116, in auth
new_tokens = web.get_valid_token(headers)
File "/code/app/auth/web.py", line 97, in get_valid_token
return {"access_token": keycloak_oidc_client.access_token}
AttributeError: 'NoneType' object has no attribute 'access_token'
```