### PR TITLE
ci: update helm url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install helm
         env:
           HELM_URL: https://storage.googleapis.com/kubernetes-helm
-          HELM_TGZ: helm-v2.16.9-linux-amd64.tar.gz
+          HELM_TGZ: helm-v2.17.0-linux-amd64.tar.gz
           TEMP_DIR: ${{ runner.temp }}
         run: ./install_helm.sh
       - name: Test chart


### PR DESCRIPTION
The test-chart action uses the helm version 2.16.9. We need to update to version >= 2.17.0 to prevent it from failing as in https://github.com/SwissDataScienceCenter/renku-ui/runs/1649868184

Reference: https://helm.sh/blog/new-location-stable-incubator-charts/