### PR TITLE
chore: adapt ci/cd logic

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -52,7 +52,7 @@ jobs:
         RENKU_TESTS_ENABLED: true
         TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
         renku_gateway: "@${{ github.head_ref }}"
-        renku: "@development"
+        renku: "@master"
     - name: Check existing renkubot comment
       uses: peter-evans/find-comment@v1
       id: findcomment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
   publish-chart:
     runs-on: ubuntu-latest
     needs: test-chart
-    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
+    if: "startsWith(github.ref, 'refs/tags/')"
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
- Update renku requirements only when a new version is released.
- Run ci deployements / acceptance tests against the main branch in renku.
closes #365.