### PR TITLE
feat: add routing for kg requests

### DIFF
--- a/app/auth/gitlab_auth.py
+++ b/app/auth/gitlab_auth.py
@@ -72,9 +72,6 @@ class GitlabUserToken:
                 headers[
                     "Renku-Token"
                 ] = access_token  # can be needed later in the request processing
-            if "details" in request.args:
-                if request.args.get("details") == "userId":
-                    headers["x-gitlab-user-id"] = "TBA"
 
         else:
             current_app.logger.debug(

--- a/app/auth/gitlab_auth.py
+++ b/app/auth/gitlab_auth.py
@@ -72,6 +72,9 @@ class GitlabUserToken:
                 headers[
                     "Renku-Token"
                 ] = access_token  # can be needed later in the request processing
+            if "details" in request.args:
+                if request.args.get("details") == "userId":
+                    headers["x-gitlab-user-id"] = "TBA"
 
         else:
             current_app.logger.debug(

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -123,6 +123,12 @@ data:
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}renku`)"
           Service = "core"
 
+        [http.routers.kg]
+          entryPoints = ["http"]
+          Middlewares = ["auth-gitlab-with-id", "common", "kg", "knowledgeGraph"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}kg`)"
+          Service = "knowledgeGraph"
+
       [http.middlewares]
 
         # We assume entity IDs which are URL-safe except <namespace>/<project-name>
@@ -185,6 +191,11 @@ data:
           trustForwardHeader = true
           authResponseHeaders = ["Authorization"]
 
+        [http.middlewares.auth-gitlab-with-id.forwardauth]
+          address = "http://{{ template "gateway.fullname" . }}-auth/?auth=gitlab&details=userId"
+          trustForwardHeader = true
+          authResponseHeaders = ["Authorization", "x-gitlab-user-id"]
+
         [http.middlewares.auth-jupyterhub.forwardauth]
           address = "http://{{ template "gateway.fullname" . }}-auth/?auth=jupyterhub"
           trustForwardHeader = true
@@ -220,6 +231,9 @@ data:
             period = "{{ .Values.rateLimits.general.period }}"
             average = {{ .Values.rateLimits.general.average }}
             burst = {{ .Values.rateLimits.general.burst }}
+
+        [http.middlewares.kg.StripPrefix]
+          prefixes = ["/kg"]
 
       [http.services]
         [http.services.gateway.LoadBalancer]

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -125,7 +125,7 @@ data:
 
         [http.routers.kg]
           entryPoints = ["http"]
-          Middlewares = ["auth-gitlab-with-id", "common", "kg", "knowledgeGraph"]
+          Middlewares = ["auth-gitlab", "common", "kg", "knowledgeGraph"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}kg`)"
           Service = "knowledgeGraph"
 
@@ -190,11 +190,6 @@ data:
           address = "http://{{ template "gateway.fullname" . }}-auth/?auth=gitlab"
           trustForwardHeader = true
           authResponseHeaders = ["Authorization"]
-
-        [http.middlewares.auth-gitlab-with-id.forwardauth]
-          address = "http://{{ template "gateway.fullname" . }}-auth/?auth=gitlab&details=userId"
-          trustForwardHeader = true
-          authResponseHeaders = ["Authorization", "x-gitlab-user-id"]
 
         [http.middlewares.auth-jupyterhub.forwardauth]
           address = "http://{{ template "gateway.fullname" . }}-auth/?auth=jupyterhub"


### PR DESCRIPTION
This adds the `/api/kg` routing for the knowledge graph APIs. The GitLab token is added to the requests in the `Authorization` headers as `Bearer <gitlab-access-token>`

We can later remove the routes for `/graphql` since it's now accessible from `/kg/graphql` -- I'm delaying that to simplify merging the PR by not introducing braking changes.

This PR is already used in the test deployment https://lorenzotest.dev.renku.ch/

/deploy
fix #300
