### PR TITLE
Remove legacy routes to access knowledge graph resources

### DIFF
--- a/app/auth/gitlab_auth.py
+++ b/app/auth/gitlab_auth.py
@@ -72,9 +72,6 @@ class GitlabUserToken:
                 headers[
                     "Renku-Token"
                 ] = access_token  # can be needed later in the request processing
-            if "details" in request.args:
-                if request.args.get("details") == "userId":
-                    headers["x-gitlab-user-id"] = "TBA"
 
         else:
             current_app.logger.debug(

--- a/app/auth/gitlab_auth.py
+++ b/app/auth/gitlab_auth.py
@@ -72,6 +72,9 @@ class GitlabUserToken:
                 headers[
                     "Renku-Token"
                 ] = access_token  # can be needed later in the request processing
+            if "details" in request.args:
+                if request.args.get("details") == "userId":
+                    headers["x-gitlab-user-id"] = "TBA"
 
         else:
             current_app.logger.debug(

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -123,6 +123,12 @@ data:
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}renku`)"
           Service = "core"
 
+        [http.routers.kg]
+          entryPoints = ["http"]
+          Middlewares = ["auth-gitlab-with-id", "common", "kg", "knowledgeGraph"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}kg`)"
+          Service = "knowledgeGraph"
+
       [http.middlewares]
 
         # We assume entity IDs which are URL-safe except <namespace>/<project-name>
@@ -185,6 +191,11 @@ data:
           trustForwardHeader = true
           authResponseHeaders = ["Authorization"]
 
+        [http.middlewares.auth-gitlab-with-id.forwardauth]
+          address = "http://{{ template "gateway.fullname" . }}-auth/?auth=gitlab&details=userId"
+          trustForwardHeader = true
+          authResponseHeaders = ["Authorization", "x-gitlab-user-id"]
+
         [http.middlewares.auth-jupyterhub.forwardauth]
           address = "http://{{ template "gateway.fullname" . }}-auth/?auth=jupyterhub"
           trustForwardHeader = true
@@ -220,6 +231,9 @@ data:
             period = "{{ .Values.rateLimits.general.period }}"
             average = {{ .Values.rateLimits.general.average }}
             burst = {{ .Values.rateLimits.general.burst }}
+
+        [http.middlewares.kg.StripPrefix]
+          prefixes = ["/kg"]
 
       [http.services]
         [http.services.gateway.LoadBalancer]

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -125,7 +125,7 @@ data:
 
         [http.routers.kg]
           entryPoints = ["http"]
-          Middlewares = ["auth-gitlab-with-id", "common", "kg", "knowledgeGraph"]
+          Middlewares = ["auth-gitlab", "common", "kg", "knowledgeGraph"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}kg`)"
           Service = "knowledgeGraph"
 
@@ -190,11 +190,6 @@ data:
           address = "http://{{ template "gateway.fullname" . }}-auth/?auth=gitlab"
           trustForwardHeader = true
           authResponseHeaders = ["Authorization"]
-
-        [http.middlewares.auth-gitlab-with-id.forwardauth]
-          address = "http://{{ template "gateway.fullname" . }}-auth/?auth=gitlab&details=userId"
-          trustForwardHeader = true
-          authResponseHeaders = ["Authorization", "x-gitlab-user-id"]
 
         [http.middlewares.auth-jupyterhub.forwardauth]
           address = "http://{{ template "gateway.fullname" . }}-auth/?auth=jupyterhub"

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -81,18 +81,6 @@ data:
           Rule = "Path(`{{ .Values.gatewayServicePrefix | default "/api/" }}projects/{project-id}/graph/status{endpoint:(.*)}`)"
           Service = "webhooks"
 
-        [http.routers.graphql]
-          entryPoints = ["http"]
-          Middlewares = ["common", "graphql"]
-          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}graphql`)"
-          Service = "graphql"
-
-        [http.routers.datasets]
-          entryPoints = ["http"]
-          Middlewares = ["common", "knowledgeGraph"]
-          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}datasets`)"
-          Service = "knowledgeGraph"
-
         [http.routers.direct]
           # This is to access undocumented APIs in GitLab
           entryPoints = ["http"]
@@ -125,7 +113,7 @@ data:
 
         [http.routers.kg]
           entryPoints = ["http"]
-          Middlewares = ["auth-gitlab", "common", "kg", "knowledgeGraph"]
+          Middlewares = ["auth-gitlab", "common", "knowledgeGraph"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}kg`)"
           Service = "knowledgeGraph"
 
@@ -209,12 +197,9 @@ data:
           regex = "^/projects/([^/]*)/graph(.*)"
           replacement = "/projects/$1/events$2"
 
-        [http.middlewares.graphql.ReplacePathRegex]
-          regex = "/graphql"
-          replacement = "/knowledge-graph/graphql"
-
-        [http.middlewares.knowledgeGraph.AddPrefix]
-          prefix = "/knowledge-graph"
+        [http.middlewares.knowledgeGraph.ReplacePathRegex]
+          regex = "^/kg/(.*)"
+          replacement = "/knowledge-graph/$1"
 
         [http.middlewares.direct.ReplacePathRegex]
           regex = "^/api/direct/(.*)"
@@ -226,9 +211,6 @@ data:
             period = "{{ .Values.rateLimits.general.period }}"
             average = {{ .Values.rateLimits.general.average }}
             burst = {{ .Values.rateLimits.general.burst }}
-
-        [http.middlewares.kg.StripPrefix]
-          prefixes = ["/kg"]
 
       [http.services]
         [http.services.gateway.LoadBalancer]
@@ -257,13 +239,6 @@ data:
           passHostHeader = false
           [[http.services.webhooks.LoadBalancer.servers]]
             url = {{ .Values.graph.webhookService.hostname | default (printf "http://%s-webhook-service" .Release.Name ) | quote }}
-            weight = 1
-
-        [http.services.graphql.LoadBalancer]
-          method = "drr"
-          passHostHeader = false
-          [[http.services.graphql.LoadBalancer.servers]]
-          url = {{ .Values.graph.knowledgeGraph.hostname | default (printf "http://%s-knowledge-graph" .Release.Name ) | quote }}
             weight = 1
 
         [http.services.knowledgeGraph.LoadBalancer]


### PR DESCRIPTION
This PR removes the old unauthenticated routes to access the knowledge graph.
Follow-up of #382 

/deploy
