### PR TITLE
ci: enforce deploy string command

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -21,6 +21,12 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       pr-contains-string: ${{ steps.deploy-comment.outputs.pr-contains-string }}
+      renku: ${{ steps.deploy-comment.outputs.renku}}
+      renku-core: ${{ steps.deploy-comment.outputs.renku-core}}
+      renku-gateway: ${{ steps.deploy-comment.outputs.renku-gateway}}
+      renku-graph: ${{ steps.deploy-comment.outputs.renku-graph}}
+      renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
+      test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
     steps:
       - id: deploy-comment
         uses: SwissDataScienceCenter/renku/actions/check-pr-description@master
@@ -52,7 +58,11 @@ jobs:
         RENKU_TESTS_ENABLED: true
         TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
         renku_gateway: "@${{ github.head_ref }}"
-        renku: "@master"
+        renku: "${{ needs.check-deploy.outputs.renku }}"
+        renku_core: "${{ needs.check-deploy.outputs.renku-core }}"
+        renku_graph: "${{ needs.check-deploy.outputs.renku-graph }}"
+        renku_notebooks: "${{ needs.check-deploy.outputs.renku-notebooks }}"
+        renku_ui: "${{ needs.check-deploy.outputs.renku-ui }}"
     - name: Check existing renkubot comment
       uses: peter-evans/find-comment@v1
       id: findcomment
@@ -79,7 +89,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Test the PR
-      if: needs.check-deploy.outputs.pr-contains-string == 'true'
+      if: "needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'"
       env:
         KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}

--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -23,9 +23,9 @@ jobs:
       pr-contains-string: ${{ steps.deploy-comment.outputs.pr-contains-string }}
       renku: ${{ steps.deploy-comment.outputs.renku}}
       renku-core: ${{ steps.deploy-comment.outputs.renku-core}}
-      renku-gateway: ${{ steps.deploy-comment.outputs.renku-gateway}}
       renku-graph: ${{ steps.deploy-comment.outputs.renku-graph}}
       renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
+      renku-ui: ${{ steps.deploy-comment.outputs.renku-ui}}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
     steps:
       - id: deploy-comment

--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -96,7 +96,7 @@ jobs:
         RENKU_RELEASE: renku-ci-gw-${{ github.event.number }}
       run: |
         echo "$RENKUBOT_KUBECONFIG" > ${{ github.workspace }}/renkubot-kube.config
-        helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 40m --logs
+        helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 80m --logs
     - name: Download artifact for packaging on failure
       if: failure()
       uses: SwissDataScienceCenter/renku/actions/download-test-artifacts@master


### PR DESCRIPTION
Add the possibility to provide details to the `/ deploy` command.
Info: https://github.com/SwissDataScienceCenter/renku/pull/2073/files?short_path=e969017#diff-e969017621edbe724f851ca789090af791987d4a7386f2eb4ec5f85c58156baa

/deploy #notest renku-ui=0.11.8
