### PR TITLE
feat: add renku headers to nb service requests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,7 +34,7 @@ from simplekv.decorator import PrefixDecorator
 from simplekv.memory.redisstore import RedisStore
 
 from . import config
-from .auth import cli_auth, gitlab_auth, jupyterhub_auth, renku_auth, web
+from .auth import cli_auth, gitlab_auth, jupyterhub_auth, renku_auth, web, notebook_auth
 from .auth.oauth_redis import OAuthRedis
 from .auth.utils import decode_keycloak_jwt
 
@@ -99,6 +99,7 @@ def auth():
         "gitlab": gitlab_auth.GitlabUserToken,
         "jupyterhub": jupyterhub_auth.JupyterhubUserToken,
         "renku": renku_auth.RenkuCoreAuthHeaders,
+        "notebook": notebook_auth.NotebookAuthHeaders,
     }
 
     # Keycloak public key is not defined so error

--- a/app/auth/notebook_auth.py
+++ b/app/auth/notebook_auth.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Add the headers for the Renku notebooks service."""
+import json
+import re
+from base64 import b64encode
+
+from flask import current_app
+
+from .gitlab_auth import GL_SUFFIX
+from .utils import get_redis_key_from_token
+from .web import KC_SUFFIX
+
+# TODO: This is a temporary implementation of the header interface defined in #404
+# TODO: that allowes first clients to transition.
+
+
+def get_git_credentials_header(git_oauth_clients):
+    """
+    Create the git authentication header as defined in #406
+    (https://github.com/SwissDataScienceCenter/renku-gateway/issues/406)
+    given a list of GitLab/GitHub oauth client objects.
+    """
+
+    git_credentials = {
+        client.provider_app.base_url: {
+            # TODO: add this information to the provider_app and read it from there.
+            "provider": "GitLab",
+            "AuthorizationHeader": f"bearer {client.access_token}",
+        }
+        for client in git_oauth_clients
+    }
+    git_credentials_json = json.dumps(git_credentials)
+    return b64encode(git_credentials_json.encode()).decode("ascii")
+
+
+class NotebookAuthHeaders:
+    def process(self, request, headers):
+
+        m = re.search(
+            r"bearer (?P<token>.+)", headers.get("Authorization", ""), re.IGNORECASE
+        )
+        if m:
+            access_token = m.group("token")
+
+            keycloak_oidc_client = current_app.store.get_oauth_client(
+                get_redis_key_from_token(access_token, key_suffix=KC_SUFFIX)
+            )
+            gitlab_oauth_client = current_app.store.get_oauth_client(
+                get_redis_key_from_token(access_token, key_suffix=GL_SUFFIX)
+            )
+
+            headers["Renku-Auth-Access-Token"] = access_token
+            headers["Renku-Auth-Id-Token"] = keycloak_oidc_client.token["id_token"]
+            headers["Renku-Auth-Git-Credentials"] = get_git_credentials_header(
+                [gitlab_oauth_client]
+            )
+
+        return headers

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -64,7 +64,7 @@ data:
 {{ if eq .Values.global.anonymousSessions.enabled false }}
         [http.routers.notebooks]
           entryPoints = ["http"]
-          Middlewares = ["auth-jupyterhub", "common", "notebooks"]
+          Middlewares = ["auth-jupyterhub", "auth-notebook", "common", "notebooks"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}notebooks`)"
           Service = "jupyterhub"
 {{ end }}
@@ -201,6 +201,11 @@ data:
           trustForwardHeader = true
           authResponseHeaders = ["Authorization", "Renku-user-id", "Renku-user-fullname", "Renku-user-email"]
 
+        [http.middlewares.auth-notebook.forwardauth]
+          address = "http://{{ template "gateway.fullname" . }}-auth/?auth=notebook"
+          trustForwardHeader = true
+          authResponseHeaders = ["Renku-Auth-Access-Token", "Renku-Auth-Id-Token", "Renku-Auth-Git-Credentials"]
+
         [http.middlewares.webhooks.ReplacePathRegex]
           regex = "^/projects/([^/]*)/graph/webhooks(.*)"
           replacement = "/projects/$1/webhooks$2"
@@ -320,7 +325,7 @@ data:
         [http.routers.notebooksSecondPassRegular]
           priority=1003
           entryPoints = ["http"]
-          Middlewares = ["common", "notebooks"]
+          Middlewares = ["auth-notebook", "common", "notebooks"]
           Rule = "PathPrefix(`/notebooks-second-pass`) && HeadersRegexp(`Authorization`, `token`)"
           Service = "jupyterhub"
 


### PR DESCRIPTION
This PR adds the header
`Renku-Gitlab-Accesstoken: <some-token>`
together with some other Renku specific header to authenticated requests to the notebooks service. Note that this is only a temporary solution as the expected header names / content will be synchronized between the different renku backend services.

/deploy