### PR TITLE
feat(auth): add anonymous id to cookie

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import sys
 
 import jwt
@@ -92,6 +93,7 @@ blueprints = (
 @app.route("/", methods=["GET"])
 def auth():
     current_app.logger.debug(f"Hitting gateway auth with args: {request.args}")
+
     if "auth" not in request.args:
         return Response("", status=200)
 
@@ -180,6 +182,22 @@ def auth():
         return Response(json.dumps(message), status=401)
 
     current_app.logger.debug(f"Returning headers {headers}")
+
+    if (
+        "anon-id" not in request.cookies
+        and request.headers.get("X-Requested-With", "") == "XMLHttpRequest"
+        and request.headers["X-Forwarded-Uri"] == "/api/user"
+        and "Authorization" not in headers
+    ):
+        resp = Response(
+            json.dumps({"message": "401 Unauthorized"}),
+            content_type="application/json",
+            status=401,
+        )
+        resp.set_cookie("anon-id", secrets.token_hex(64), path="/api/")
+        current_app.logger.debug("Setting anonymous id")
+        return resp
+
     return Response(json.dumps("Up and running"), headers=headers, status=200,)
 
 

--- a/app/auth/notebook_auth.py
+++ b/app/auth/notebook_auth.py
@@ -52,6 +52,8 @@ def get_git_credentials_header(git_oauth_clients):
 class NotebookAuthHeaders:
     def process(self, request, headers):
 
+        headers["Renku-Auth-Anon-Id"] = request.cookies.get("anon-id", "")
+
         m = re.search(
             r"bearer (?P<token>.+)", headers.get("Authorization", ""), re.IGNORECASE
         )


### PR DESCRIPTION
This adds an anonymous id `anon-id` to the cookie. The actual ID is added as `Renku-Auth-Anon-Id` header to notebook server requests, independent on wether the user is authenticated or not. 

caveats:
- once the UI server is ready, such a anonymous ID should be provided by the UI server
- for this to work properly, the UI needs to retry the very first AJAX request which sets the anonymous id in the cookie (a page reload will do as well until this is implemented).

/deploy