### PR TITLE
Add GitLab auth to /direct endpoints

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -86,7 +86,8 @@ data:
           # This is to access undocumented APIs in GitLab
           entryPoints = ["http"]
           Middlewares = [
-            "direct"
+            "auth-gitlab",
+            "direct",
             {{- if .Values.global.gitlab.urlPrefix -}}
             {{- if and (ne .Values.global.gitlab.urlPrefix "") (ne .Values.global.gitlab.urlPrefix "/") -}}
             ,"gitlabOnly"


### PR DESCRIPTION
The route `/api/direct` already exists to bypass the usual `/api/v4` prefix we add to queries going to GitLab.
The UI now requires access to GraphQL ( SwissDataScienceCenter/renku-ui#1529 ) .

We could use this rule, adding the GitLab access token when the user is authenticated.

/deploy
