### PR TITLE
Add GitLab auth to /direct endpoints

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -86,7 +86,7 @@ data:
           # This is to access undocumented APIs in GitLab
           entryPoints = ["http"]
           Middlewares = [
-            "auth-gitlab","direct"
+            "direct"
             {{- if .Values.global.gitlab.urlPrefix -}}
             {{- if and (ne .Values.global.gitlab.urlPrefix "") (ne .Values.global.gitlab.urlPrefix "/") -}}
             ,"gitlabOnly"
@@ -94,6 +94,20 @@ data:
             {{- end }}
           ]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}direct/`)"
+          Service = "gitlab"
+        
+        [http.routers.gitlabGraphql]
+          entryPoints = ["http"]
+          Middlewares = [
+            "auth-gitlab","general-ratelimit","api"
+            {{- if .Values.global.gitlab.urlPrefix -}}
+            {{- if and (ne .Values.global.gitlab.urlPrefix "") (ne .Values.global.gitlab.urlPrefix "/") -}}
+            ,"gitlabOnly"
+            {{- end -}}
+            {{- end }}
+            ,"gitlabGraphql"
+          ]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}graphql`)"
           Service = "gitlab"
 
         [http.routers.gitlab]
@@ -225,6 +239,10 @@ data:
         [http.middlewares.direct.ReplacePathRegex]
           regex = "^/api/direct/(.*)"
           replacement = "/$1"
+
+        [http.middlewares.gitlabGraphql.ReplacePathRegex]
+          regex = "(.*)/graphql(.*)"
+          replacement = "/$1/api/graphql$2"
 
         [http.middlewares.general-ratelimit.ratelimit]
           extractorfunc = "{{ .Values.rateLimits.general.extractorfunc }}"

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -86,8 +86,7 @@ data:
           # This is to access undocumented APIs in GitLab
           entryPoints = ["http"]
           Middlewares = [
-            "auth-gitlab",
-            "direct",
+            "auth-gitlab","direct"
             {{- if .Values.global.gitlab.urlPrefix -}}
             {{- if and (ne .Values.global.gitlab.urlPrefix "") (ne .Values.global.gitlab.urlPrefix "/") -}}
             ,"gitlabOnly"

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -86,7 +86,8 @@ data:
           # This is to access undocumented APIs in GitLab
           entryPoints = ["http"]
           Middlewares = [
-            "direct"
+            "auth-gitlab",
+            "direct",
             {{- if .Values.global.gitlab.urlPrefix -}}
             {{- if and (ne .Values.global.gitlab.urlPrefix "") (ne .Values.global.gitlab.urlPrefix "/") -}}
             ,"gitlabOnly"


### PR DESCRIPTION
The route `/api/direct` already exists to bypass the usual `/api/v4` prefix we add to queries going to GitLab.
The UI now requires access to GraphQL ( SwissDataScienceCenter/renku-ui#1529 ) .

We could use this rule, adding the GitLab access token when the user is authenticated.

/deploy
