### PR TITLE
493 gitlab urls

### DIFF
--- a/helm-chart/renku-gateway/Chart.yaml
+++ b/helm-chart/renku-gateway/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '2.0'
 description: A Helm chart for the Renku gateway
 name: renku-gateway
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.10.2
+version: 0.10.2-n004.h08f8989

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -85,28 +85,13 @@ data:
         [http.routers.direct]
           # This is to access undocumented APIs in GitLab
           entryPoints = ["http"]
-          Middlewares = [
-            "direct"
-            {{- if .Values.global.gitlab.urlPrefix -}}
-            {{- if and (ne .Values.global.gitlab.urlPrefix "") (ne .Values.global.gitlab.urlPrefix "/") -}}
-            ,"gitlabOnly"
-            {{- end -}}
-            {{- end }}
-          ]
+          Middlewares = ["direct", "NG_gitlabPrefix"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}direct/`)"
           Service = "gitlab"
         
         [http.routers.gitlabGraphql]
           entryPoints = ["http"]
-          Middlewares = [
-            "auth-gitlab","general-ratelimit","api"
-            {{- if .Values.global.gitlab.urlPrefix -}}
-            {{- if and (ne .Values.global.gitlab.urlPrefix "") (ne .Values.global.gitlab.urlPrefix "/") -}}
-            ,"gitlabOnly"
-            {{- end -}}
-            {{- end }}
-            ,"gitlabGraphql"
-          ]
+          Middlewares = ["auth-gitlab", "general-ratelimit", "api", "NG_gitlabPrefix", "gitlabGraphql"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}graphql`)"
           Service = "gitlab"
 
@@ -116,14 +101,14 @@ data:
           # possible value.
           priority = 1
           entryPoints = ["http"]
-          Middlewares = ["auth-gitlab", "common", "gitlabApi"]
+          Middlewares = ["auth-gitlab", "common", "NG_gitlabPrefix", "NG_gitlabApi"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}`)"
           Service = "gitlab"
 
         [http.routers.gitlabRenkuCli]
           # Access to gitlab server from a git repo with CLI token
           entryPoints = ["http"]
-          Middlewares = ["auth-cliGitlab", "common", "cliGitlab"]
+          Middlewares = ["auth-cliGitlab", "common", "NG_gitlabPrefix", "NG_gitlabCli"]
           Rule = "PathPrefix(`{{ .Values.global.gitlab.cliUrlPrefix | default "/repos/" }}`)"
           Service = "gitlab"
 
@@ -176,9 +161,29 @@ data:
         [http.middlewares.development.headers]
           isDevelopment = true
 
+        [http.middlewares.NG_gitlabPrefix.AddPrefix]
+          prefix = "/{{ trimSuffix `/` (trimPrefix `/` .Values.global.gitlab.urlPrefix | default "") }}"
+        
+        [http.middlewares.NG_gitlabApi.AddPrefix]
+          prefix = "api/v4/"
+
+        [http.middlewares.NG_gitlabCli.ReplacePathRegex]
+          regex = "^/repos/(.*)"
+          replacement = "$1"
+
+        [http.middlewares.gitlabGraphql.ReplacePathRegex]
+          regex = "(.*)/graphql(.*)"
+          replacement = "/$1/api/graphql$2"
+
+        [http.middlewares.direct.ReplacePathRegex]
+          regex = "^/api/direct/(.*)"
+          replacement = "/$1"
+
+        # REMOVE
         [http.middlewares.gitlabOnly.AddPrefix]
           prefix = "{{ .Values.global.gitlab.urlPrefix }}"
 
+        # REMOVE
         [http.middlewares.gitlabApi.AddPrefix]
           {{ if eq .Values.global.gitlab.urlPrefix "/" }}
           prefix = "/api/v4"
@@ -186,6 +191,7 @@ data:
           prefix = "{{ .Values.global.gitlab.urlPrefix }}/api/v4"
           {{ end }}
 
+        # REMOVE
         [http.middlewares.cliGitlab.ReplacePathRegex]
           regex = "^/repos/(.*)"
           {{ if eq .Values.global.gitlab.urlPrefix "/" }}
@@ -235,14 +241,6 @@ data:
 
         [http.middlewares.knowledgeGraph.AddPrefix]
           prefix = "/knowledge-graph"
-
-        [http.middlewares.direct.ReplacePathRegex]
-          regex = "^/api/direct/(.*)"
-          replacement = "/$1"
-
-        [http.middlewares.gitlabGraphql.ReplacePathRegex]
-          regex = "(.*)/graphql(.*)"
-          replacement = "/$1/api/graphql$2"
 
         [http.middlewares.general-ratelimit.ratelimit]
           extractorfunc = "{{ .Values.rateLimits.general.extractorfunc }}"

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -263,7 +263,7 @@ data:
           method = "drr"
           passHostHeader = false
           [[http.services.gitlab.LoadBalancer.servers]]
-            url = {{ .Values.gitlabUrl | default (printf "%s://%s/gitlab" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
+            url = {{ .Values.gitlabUrl | default (printf "%s://%s%s" (include "gateway.protocol" .) .Values.global.renku.domain .Values.global.gitlab.urlPrefix) | quote }}
             weight = 1
 
         [http.services.notebooks.LoadBalancer]

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -162,10 +162,10 @@ data:
           isDevelopment = true
 
         [http.middlewares.gitlabPrefix.AddPrefix]
-          prefix = "{{ trimSuffix `/` (printf "/%s" ( trimPrefix `/` .Values.global.gitlab.urlPrefix | default "" )) }}"
+          prefix = "{{ (printf "%s/" (trimSuffix `/` (printf "/%s" ( trimPrefix `/` .Values.global.gitlab.urlPrefix | default "" )))) }}"
         
         [http.middlewares.gitlabApi.AddPrefix]
-          prefix = "/api/v4"
+          prefix = "api/v4"
 
         [http.middlewares.gitlabCli.ReplacePathRegex]
           regex = "^/repos/(.*)"

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -165,11 +165,11 @@ data:
           prefix = "/{{ trimSuffix `/` (trimPrefix `/` .Values.global.gitlab.urlPrefix | default "") }}"
         
         [http.middlewares.NG_gitlabApi.AddPrefix]
-          prefix = "api/v4/"
+          prefix = "/api/v4"
 
         [http.middlewares.NG_gitlabCli.ReplacePathRegex]
           regex = "^/repos/(.*)"
-          replacement = "$1"
+          replacement = "/$1"
 
         [http.middlewares.gitlabGraphql.ReplacePathRegex]
           regex = "(.*)/graphql(.*)"

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -76,23 +76,42 @@ data:
           Rule = "Path(`{{ .Values.gatewayServicePrefix | default "/api/" }}projects/{project-id}/graph/status{endpoint:(.*)}`)"
           Service = "webhooks"
 
+        [http.routers.kg]
+          entryPoints = ["http"]
+          Middlewares = ["auth-gitlab", "common", "kg", "knowledgeGraph"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}kg`)"
+          Service = "knowledgeGraph"
+
         [http.routers.datasets]
           entryPoints = ["http"]
           Middlewares = ["common", "knowledgeGraph"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}datasets`)"
           Service = "knowledgeGraph"
 
+        [http.routers.renku]
+          entryPoints = ["http"]
+          Middlewares = ["auth-renku", "common"]
+          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}renku`)"
+          Service = "core"
+
         [http.routers.direct]
           # This is to access undocumented APIs in GitLab
           entryPoints = ["http"]
-          Middlewares = ["direct", "NG_gitlabPrefix"]
+          Middlewares = ["direct", "gitlabPrefix"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}direct/`)"
           Service = "gitlab"
         
         [http.routers.gitlabGraphql]
           entryPoints = ["http"]
-          Middlewares = ["auth-gitlab", "general-ratelimit", "api", "NG_gitlabPrefix", "gitlabGraphql"]
+          Middlewares = ["auth-gitlab", "general-ratelimit", "api", "gitlabGraphql", "gitlabPrefix"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}graphql`)"
+          Service = "gitlab"
+
+        [http.routers.gitlabRenkuCli]
+          # Access to gitlab server from a git repo with CLI token
+          entryPoints = ["http"]
+          Middlewares = ["auth-cliGitlab", "common", "gitlabCli", "gitlabPrefix"]
+          Rule = "PathPrefix(`{{ .Values.global.gitlab.cliUrlPrefix | default "/repos/" }}`)"
           Service = "gitlab"
 
         [http.routers.gitlab]
@@ -101,28 +120,9 @@ data:
           # possible value.
           priority = 1
           entryPoints = ["http"]
-          Middlewares = ["auth-gitlab", "common", "NG_gitlabPrefix", "NG_gitlabApi"]
+          Middlewares = ["auth-gitlab", "common", "gitlabApi", "gitlabPrefix"]
           Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}`)"
           Service = "gitlab"
-
-        [http.routers.gitlabRenkuCli]
-          # Access to gitlab server from a git repo with CLI token
-          entryPoints = ["http"]
-          Middlewares = ["auth-cliGitlab", "common", "NG_gitlabPrefix", "NG_gitlabCli"]
-          Rule = "PathPrefix(`{{ .Values.global.gitlab.cliUrlPrefix | default "/repos/" }}`)"
-          Service = "gitlab"
-
-        [http.routers.renku]
-          entryPoints = ["http"]
-          Middlewares = ["auth-renku", "common"]
-          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}renku`)"
-          Service = "core"
-
-        [http.routers.kg]
-          entryPoints = ["http"]
-          Middlewares = ["auth-gitlab", "common", "kg", "knowledgeGraph"]
-          Rule = "PathPrefix(`{{ .Values.gatewayServicePrefix | default "/api/" }}kg`)"
-          Service = "knowledgeGraph"
 
       [http.middlewares]
 
@@ -161,13 +161,13 @@ data:
         [http.middlewares.development.headers]
           isDevelopment = true
 
-        [http.middlewares.NG_gitlabPrefix.AddPrefix]
-          prefix = "/{{ trimSuffix `/` (trimPrefix `/` .Values.global.gitlab.urlPrefix | default "") }}"
+        [http.middlewares.gitlabPrefix.AddPrefix]
+          prefix = "{{ trimSuffix `/` (printf "/%s" ( trimPrefix `/` .Values.global.gitlab.urlPrefix | default "" )) }}"
         
-        [http.middlewares.NG_gitlabApi.AddPrefix]
+        [http.middlewares.gitlabApi.AddPrefix]
           prefix = "/api/v4"
 
-        [http.middlewares.NG_gitlabCli.ReplacePathRegex]
+        [http.middlewares.gitlabCli.ReplacePathRegex]
           regex = "^/repos/(.*)"
           replacement = "/$1"
 
@@ -178,27 +178,6 @@ data:
         [http.middlewares.direct.ReplacePathRegex]
           regex = "^/api/direct/(.*)"
           replacement = "/$1"
-
-        # REMOVE
-        [http.middlewares.gitlabOnly.AddPrefix]
-          prefix = "{{ .Values.global.gitlab.urlPrefix }}"
-
-        # REMOVE
-        [http.middlewares.gitlabApi.AddPrefix]
-          {{ if eq .Values.global.gitlab.urlPrefix "/" }}
-          prefix = "/api/v4"
-          {{- else -}}
-          prefix = "{{ .Values.global.gitlab.urlPrefix }}/api/v4"
-          {{ end }}
-
-        # REMOVE
-        [http.middlewares.cliGitlab.ReplacePathRegex]
-          regex = "^/repos/(.*)"
-          {{ if eq .Values.global.gitlab.urlPrefix "/" }}
-          replacement = "/$1"
-          {{- else -}}
-          replacement = "{{ .Values.global.gitlab.urlPrefix }}/$1"
-          {{ end }}
 
         [http.middlewares.auth-gitlab.forwardauth]
           address = "http://{{ template "gateway.fullname" . }}-auth/?auth=gitlab"

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -173,7 +173,7 @@ data:
 
         [http.middlewares.gitlabGraphql.ReplacePathRegex]
           regex = "(.*)/graphql(.*)"
-          replacement = "/$1/api/graphql$2"
+          replacement = "$1/api/graphql$2"
 
         [http.middlewares.direct.ReplacePathRegex]
           regex = "^/api/direct/(.*)"

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -161,8 +161,9 @@ data:
         [http.middlewares.development.headers]
           isDevelopment = true
 
-        [http.middlewares.gitlabPrefix.AddPrefix]
-          prefix = "{{ (printf "%s/" (trimSuffix `/` (printf "/%s" ( trimPrefix `/` .Values.global.gitlab.urlPrefix | default "" )))) }}"
+        [http.middlewares.gitlabPrefix.ReplacePathRegex]
+          regex = "^/(.*)"
+          replacement = "{{ (printf "%s/" (trimSuffix `/` (printf "/%s" ( trimPrefix `/` .Values.global.gitlab.urlPrefix | default "" )))) }}$1"
         
         [http.middlewares.gitlabApi.AddPrefix]
           prefix = "api/v4"

--- a/helm-chart/renku-gateway/templates/deployment.yaml
+++ b/helm-chart/renku-gateway/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
                   name: {{ template "gateway.fullname" . }}
                   key: cliClientSecret
             - name: GITLAB_URL
-              value: {{ .Values.gitlabUrl | default (printf "%s://%s/gitlab" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
+              value: {{ .Values.gitlabUrl | default (printf "%s://%s%s" (include "gateway.protocol" .) .Values.global.renku.domain .Values.global.gitlab.urlPrefix) | quote }}
             - name: GITLAB_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
It turns out that streamlining the logic to handle the GitLab prefix with trailing slashes is not that simple.
The main reason is the impossibility to chain multiple `addPrefix` where one returns an empty string. Also, a `/` is automatically added as the first char if it's not already there.

I also tried with a different approach, using `ReplacePathRegex` instead of multiple `addPrefix`, but that seems to fail on some project paths containing the `/` char -- it's the last version pushed in this PR.

We either need to:
- keep a few `if` here and there, but then we don't really simplify compared to the current solution
- or require to specify the full GitLab URL in the values file.

The last seems (by far) the most reasonable solution. Looking at values files, it seems that having a separate `urlPrefix` is not really useful. And we pass the full GitLab URL also as values local to other charts.
Am I missing some use for the `urlPrefix`, or is it possible it's just a leftover from the old days? Should we consider adding something like `global.gitlab.url` and removing it from the other places?

re #493 