### PR TITLE
fix(chart): fully remove parts of non-global redis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,22 +30,20 @@ jobs:
   test-chart:
     needs: test
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v1
         with:
           python-version: 3.7
       - name: Install helm
-        env:
-          HELM_URL: https://storage.googleapis.com/kubernetes-helm
-          HELM_TGZ: helm-v2.17.0-linux-amd64.tar.gz
-          TEMP_DIR: ${{ runner.temp }}
-        run: ./install_helm.sh
+        uses: azure/setup-helm@v1
+        with:
+          version: '3.8.0'
       - name: Test chart
         run: |
-          PATH=${{ runner.temp }}/linux-amd64/:$PATH
-          helm lint helm-chart/renku-gateway --set oidcClientSecret=oidc-secret,gitlabClientSecret=gitlab-secret,cliClientSecret=cli-secret
+          helm repo add renku https://swissdatasciencecenter.github.io/helm-charts/
+          helm dep update helm-chart/renku-gateway
+          helm lint helm-chart/renku-gateway --set oidcClientSecret=foo,gitlabClientSecret=bar,secretKey=foobar,cliClientSecret=barfoo,global.redis.host=test
       - name: Build chart and images
         run: |
           python -m pip install --upgrade pip pipenv

--- a/helm-chart/renku-gateway/templates/_helpers.tpl
+++ b/helm-chart/renku-gateway/templates/_helpers.tpl
@@ -42,12 +42,17 @@ http
 {{- end -}}
 {{- end -}}
 
-{{/*
-Hack for calling templates in a fake scope (until this is solved https://github.com/helm/helm/issues/3920)
-*/}}
-{{- define "call-nested" }}
-{{- $dot := index . 0 }}
-{{- $subchart := index . 1 }}
-{{- $template := index . 2 }}
-{{- include $template (dict "Chart" (dict "Name" $subchart) "Values" (index $dot.Values $subchart) "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
-{{- end }}
+{{- define "redis.host" -}}
+{{- if .Values.global.redis.host -}}
+# If global hostname for redis is found use that
+{{- .Values.global.redis.host -}}
+{{- else -}}
+{{- if hasKey .Subcharts "redis" -}}
+# If global hostname for redis is not found, then check for redis subchart and then use that
+{{- required "If a subchart for redis is used then redis.fullname should be defined." .Subcharts.redis.fullname -}}
+{{- else -}}
+# There is no redis subchart with fullname AND there is no hostname for redis in the global section - show error message
+{{- required "Either global.redis.host should be defined or a subchart for redis should be used where redis.fullname is available." .Values.global.redis.host -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm-chart/renku-gateway/templates/deployment.yaml
+++ b/helm-chart/renku-gateway/templates/deployment.yaml
@@ -96,7 +96,8 @@ spec:
       labels:
         app: {{ template "gateway.name" . }}-auth
         release: {{ .Release.Name }}
-        {{ include "call-nested" (list . "redis" "redis.fullname") }}-client: "true"
+        # The label below enables the gateway to connect to redis
+        {{ .Values.global.redis.clientLabel | default (printf "%s-%s" (include "redis.host" .) "-client") }}: "true"
     spec:
       initContainers:
         {{- include "certificates.initContainer" . | nindent 8 }}
@@ -136,7 +137,7 @@ spec:
             - name: GATEWAY_SERVICE_PREFIX
               value: {{ .Values.gatewayServicePrefix | default "/api/" | quote }}
             - name: REDIS_HOST
-              value: {{ .Values.global.redis.host | default (include "call-nested" (list . "redis" "redis.fullname")) }}
+              value: {{ template "redis.host" . }}
             - name: REDIS_IS_SENTINEL
               value: {{ .Values.global.redis.isSentinel | quote }}
             - name: REDIS_DB

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -11,15 +11,20 @@ global:
   gitlab:
     urlPrefix: /gitlab
   gateway:
-    ## Client secret of the renku client application registered in
-    ## keycloak.
+    ## Client secret of the renku client application registered in keycloak.
+    ## Should be set to a proper value (i.e. by using openssl rand -hex 32) for production.
+    ## Can be set here or as .clientSecret outside of .global, the values set ouside of global (if defined) take precedence.
     clientSecret:
     ## Client secret of the renku-cli client application registered in keycloak.
+    ## Should be set to a proper value (i.e. by using openssl rand -hex 32) for production.
+    ## Can be set here or as .cliClientSecret outside of .global, the values set ouside of global (if defined) take precedence.
     cliClientSecret:
-    ## Client id and client secret of the renku gateway client application
-    ## which is registered in GitLab.
-    # gitlabClientId:
-    # gitlabClientSecret:
+    ## Client id and client secret of the renku gateway client application which is registered in GitLab.
+    ## Can be set here or as .gitlabClientId outside of .global, the values set ouside of global (if defined) take precedence.
+    gitlabClientId: #renku
+    ## Should be set to a proper value (i.e. by using openssl rand -hex 32) for production.
+    ## Can be set here or as .gitlabClientSecret outside of .global, the values set ouside of global (if defined) take precedence.
+    gitlabClientSecret:
   renku:
     ## Domain name for the deployed instance of Renku. Most likely
     ## set by parent chart.
@@ -53,6 +58,15 @@ global:
     customCAs: []
       # - secret:
 
+  ## Specify the information required to connect to a redis instance.
+  ## All the values below are required.
+  redis:
+    ## host is optional - defaults to {{ .Release.Name }}-redis
+    # host: 
+    isSentinel:
+    dbIndex:
+      gateway:
+
 replicaCount: 1
 
 ## Set to true to enable the developement mode. This has negative security
@@ -75,21 +89,13 @@ rateLimits:
 ## Set to a custom GitLab URL if deployed manually
 # gitlabUrl:
 
-## Configure application ID from "{{ gitlabUrl }}/oauth/application"
-## by setting redirect URL to "{{ baseUrl }}/login/redirect/gitlab"
-## and set the application ID as the "gitlabClientId" chart value.
-## The client ID for authentication against gitlab
-# gitlabClientId: renku-ui
-## The client secret for authentication against gitlab
-# gitlabClientSecret: no-secret
-
 ## You can restrict here the allowed origins for CORS.
 ## This can be a single value, a comma-separeted list or *.
 # allowOrigin: "*"
 
-## For production deployment, you will need to define the secret key
-## This is a random string, used for cryptographic operations on cookies
-## use `openssl rand -hex 32`
+## For production deployment, you will need to define the secret key.
+## This is a random string, used for cryptographic operations on cookies.
+## Use `openssl rand -hex 32`.
 secretKey:
 
 image:

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -61,8 +61,11 @@ global:
   ## Specify the information required to connect to a redis instance.
   ## All the values below are required.
   redis:
-    ## host is optional - defaults to {{ .Release.Name }}-redis
+    ## Host is optional if a subchart for redis is used, otherwise it needs to be provided below.
     # host: 
+    ## The label used to enable the network policy that allows the gateway to connect to redis.
+    ## If not defined below, it will default to <redis hostname>-client.
+    # clientLabel:
     isSentinel:
     dbIndex:
       gateway:


### PR DESCRIPTION
So these `call-nested` helpers were meant (through some witchery) to call the template of a requirement/child helm chart and pull out the redis release name which is then used in the label to allow client applications to connect to redis.

Now since we rely on a global redis instance we should not use this anymore. There is no local redis anymore.

This was causing the helm chart building/publishing step to fail: https://github.com/SwissDataScienceCenter/renku-gateway/runs/5108179637?check_suite_focus=true

/deploy #persist