### PR TITLE
chore: prep 0.12.1 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Changes
 =======
 
+`0.12.1 <https://github.com/SwissDataScienceCenter/renku-gateway/compare/0.12.0...0.12.1>`__ (2022-02-09)
+=========================================================================================================
+
+Bug Fixes
+~~~~~~~~~
+
+-  **chart:**  fully adapt to global redis
+   (`#537 <https://github.com/SwissDataScienceCenter/renku-gateway/issues/537>`__)
+   (`9003029 <(https://github.com/SwissDataScienceCenter/renku-gateway/commit/90030292fda4e65787cbfd3f1e600f625d1b11f5>`__)
+
+
 `0.12.0 <https://github.com/SwissDataScienceCenter/renku-gateway/compare/0.11.0...0.12.0>`__ (2022-02-08)
 =========================================================================================================
 

--- a/helm-chart/renku-gateway/Chart.yaml
+++ b/helm-chart/renku-gateway/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '2.0'
 description: A Helm chart for the Renku gateway
 name: renku-gateway
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.12.0
+version: 0.12.1


### PR DESCRIPTION
This includes only a fix for building the helm chart on top of `0.12.0`