### PR TITLE
fix(chart): whitespace in helm templating

### DIFF
--- a/helm-chart/renku-gateway/templates/_helpers.tpl
+++ b/helm-chart/renku-gateway/templates/_helpers.tpl
@@ -54,13 +54,14 @@ Hack for calling templates in a fake scope (until this is solved https://github.
 
 {{/*
 Define the redis hostname either from global values section or from a subchart.
+Logic:
+1. If global hostname for redis is found use that
+2. If global hostname for redis is not found, then check for redis subchart and then use that
 */}}
 {{- define "redis.host" -}}
 {{- if .Values.global.redis.host -}}
-# If global hostname for redis is found use that
-{{- .Values.global.redis.host -}}
+{{ .Values.global.redis.host -}}
 {{- else -}}
-# If global hostname for redis is not found, then check for redis subchart and then use that
-{{- required "Either global.redis.host should be defined or a subchart for redis should be used where redis.fullname is available." (include "call-nested" (list . "redis" "redis.fullname")) -}}
+{{ required "Either global.redis.host should be defined or a subchart for redis should be used where redis.fullname is available." (include "call-nested" (list . "redis" "redis.fullname")) -}}
 {{- end -}}
 {{- end -}}

--- a/helm-chart/renku-gateway/templates/deployment.yaml
+++ b/helm-chart/renku-gateway/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
         app: {{ template "gateway.name" . }}-auth
         release: {{ .Release.Name }}
         # The label below enables the gateway to connect to redis
-        {{ .Values.global.redis.clientLabel | default (printf "%s-%s" (include "redis.host" .) "-client") }}: "true"
+        {{ .Values.global.redis.clientLabel | default (printf "%s-%s" (include "redis.host" .) "client") | nindent 8 }}: "true"
     spec:
       initContainers:
         {{- include "certificates.initContainer" . | nindent 8 }}


### PR DESCRIPTION
0.12.1 cleaned up some of the helm chart templating but also unfortunately introduced a few bugs.

Not sure how the CI deployments in the PR that introduced these changes did not see this at all. I think that maybe there was an old pod that was successfully running and the new ones could never start to replace it so everything looked good.

/deploy #persist