### PR TITLE
chore(ci) Fix correct env-var for Dockerhub authentication in CI action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install helm
         uses: azure/setup-helm@v1
         with:
-          version: '3.8.0'
+          version: "3.8.0"
       - name: Test chart
         run: |
           helm repo add renku https://swissdatasciencecenter.github.io/helm-charts/
@@ -67,8 +67,8 @@ jobs:
         env:
           CHART_NAME: renku-gateway
           GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
       - name: Wait for chart to get published
         run: sleep 120
       - name: Update component version


### PR DESCRIPTION
Use the organization secrets instead of the repository ones (which will be removed).