### PR TITLE
chore(chart): remove unused values.yaml section

### DIFF
--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -117,11 +117,6 @@ rateLimits:
 secretKey:
 
 image:
-  name: traefik
-  repository: traefik
-  tag: 2.6.1
-  pullPolicy: IfNotPresent
-
   ## Define the image for the auth middleware
   auth:
     name: renku/renku-gateway


### PR DESCRIPTION
Just removed an unused part of the values file. Now that we have transitioned to the helm chart for traefik we do not need this section.
