### PR TITLE
fix(ci): docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.7-slim
 
-RUN apt-get update && apt-get install -y gcc && \
-    pip install --upgrade pip==20.1.1 && \
+RUN pip install --upgrade pip==22.1.2 && \
     pip install poetry
 
 COPY pyproject.toml poetry.lock /code/


### PR DESCRIPTION
The docker image build is failing in other PRs with the message below. 

Using the latest pip version fixes it. We also do not need to have gcc installed in the image.

```
#9 19.82   EnvCommandError
#9 19.82 
#9 19.82   Command ['/usr/local/bin/python', '-m', 'pip', 'install', '--no-deps', '-U', '/root/.cache/pypoetry/artifacts/f0/1a/11/cae8bb8eb76eda6204ce3bc7cda0fe8da4565ac1df13a98d35513cea60/cryptography-37.0.2-cp36-abi3-manylinux_2_24_x86_64.whl'] errored with the following return code 1, and output: 
#9 19.82   ERROR: cryptography-37.0.2-cp36-abi3-manylinux_2_24_x86_64.whl is not a supported wheel on this platform.
#9 19.82   WARNING: You are using pip version 20.1.1; however, version 22.1.2 is available.
#9 19.82   You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
#9 19.82   
#9 19.82 
#9 19.82   at /usr/local/lib/python3.7/site-packages/poetry/utils/env.py:1195 in _run
#9 20.08       1191│                 output = subprocess.check_output(
#9 20.09       1192│                     cmd, stderr=subprocess.STDOUT, **kwargs
#9 20.09       1193│                 )
#9 20.09       1194│         except CalledProcessError as e:
#9 20.09     → 1195│             raise EnvCommandError(e, input=input_)
#9 20.09       1196│ 
#9 20.09       1197│         return decode(output)
#9 20.09       1198│ 
#9 20.09       1199│     def execute(self, bin, *args, **kwargs):
#9 20.09 
```

/deploy #persist