### PR TITLE
chore: run CA cert injection as non-root

### DIFF
--- a/helm-chart/renku-gateway/requirements.yaml
+++ b/helm-chart/renku-gateway/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: certificates
-  version: "0.0.1"
+  version: "0.0.3"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
 - name: traefik
   version: 10.14.2

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -66,7 +66,7 @@ global:
   certificates:
     image:
       repository: renku/certificates
-      tag: "0.0.1"
+      tag: "0.0.2"
     customCAs:
       []
       # - secret:


### PR DESCRIPTION
The latest certificates image and chart can run as non-root.

This is safer than what we had before.

Also the chart and image tags are not tracking each other. This is on purpose. 

/deploy #persist