### PR TITLE
feat: redirect /gitlab to external GitLab url

### DIFF
--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -125,7 +125,7 @@ data:
         {{ if .Values.gitlabUrl }}
         [http.middlewares.gitlabRedirect.redirectRegex]
           regex = "(.*)/gitlab(.*)"
-          replacement = "{{ .Values.gitlabUrl }}${2}"
+          replacement = "{{ trimSuffix "/" .Values.gitlabUrl }}${2}"
         {{ end }}
 
         [http.middlewares.common.chain]

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -24,6 +24,14 @@ data:
           Rule = "PathPrefix(`/entities`) && HeadersRegexp(`Accept`,`text/html`)"
           Service = "default"
 
+        {{ if .Values.gitlabUrl }}
+        [http.routers.gitlabRedirect]
+          entryPoints = ["web"]
+          Middlewares = ["gitlabRedirect"]
+          Rule = "PathPrefix(`/gitlab`)"
+          Service = "default"
+        {{ end }}
+
         [http.routers.gateway]
           entryPoints = ["web"]
           Rule = "PathPrefix(`{{ printf "/%s/auth" .Values.gatewayServicePrefix | clean }}`)"
@@ -113,6 +121,12 @@ data:
         [http.middlewares.uiRedirect.redirectRegex]
           regex = "http://(.*)/entities/(.*)"
           replacement = "{{(include "gateway.protocol" .)}}://${1}/${2}"
+        
+        {{ if .Values.gitlabUrl }}
+        [http.middlewares.gitlabRedirect.redirectRegex]
+          regex = "(.*)/gitlab(.*)"
+          replacement = "{{ .Values.gitlabUrl }}${2}"
+        {{ end }}
 
         [http.middlewares.common.chain]
           middlewares = ["noCookies", "api"{{if .Values.gateway.allowOrigin }}{{", \"cors\""}}{{- end}}]


### PR DESCRIPTION
If external GitLab is used, redirect /gitlab to the external GitLab URL, including the trailing path content trailing if it exists.

This should be merged at the same time as SwissDataScienceCenter/renku#2741, which adds a rule to the standard Renku ingress to route traffic to /gitlab to renku-traefik if no Renku-bundled GitLab is deployed