### PR TITLE
fix: remove trailing slash from redirect links

### DIFF
--- a/app/templates/redirect.html
+++ b/app/templates/redirect.html
@@ -30,7 +30,7 @@
     </head>
 
     <body>
-        <p>If you are not redirected automatically, follow this <a href="{{redirect_url}}/">link.</a></p>
+        <p>If you are not redirected automatically, follow this <a href="{{redirect_url}}">link.</a></p>
     </body>
 
 </html>

--- a/app/templates/redirect_logout.html
+++ b/app/templates/redirect_logout.html
@@ -29,7 +29,7 @@
     </head>
 
     <body>
-        <p>If you are not redirected in 5 seconds, follow this <a href="{{redirect_url}}/">link.</a></p>
+        <p>If you are not redirected in 5 seconds, follow this <a href="{{redirect_url}}">link.</a></p>
         {%for i in range(0, len)%}
             <iframe src="{{logout_pages[i]}}" style="display:none;"></iframe>
         {%endfor%}


### PR DESCRIPTION
For some reason and setup in our routing navigating to `https://renku-ci-rp-3178.dev.renku.ch/api/auth/gitlab/login/` does not work and results in a 404. But if the trailing slash is removed then everything works.

It is funny because the meta tags and javascript do not contain the trailing slash and things work as expected. 

But if someone does not get redirected automatically and click the link then they will get a 404.

/deploy #persist
