### PR TITLE
feat: core service sticky sessions

### DIFF
--- a/Dockerfile.traefik
+++ b/Dockerfile.traefik
@@ -1,0 +1,11 @@
+# From: https://traefik.io/blog/using-private-plugins-in-traefik-proxy-2-5/
+FROM alpine:3 as builder
+ARG PLUGIN_MODULE=github.com/SwissDataScienceCenter/cookiefilter
+ARG PLUGIN_GIT_REPO=https://github.com/SwissDataScienceCenter/cookiefilter.git
+ARG PLUGIN_RELEASE_TAG=0.0.1
+RUN apk add --update git && \
+    git clone ${PLUGIN_GIT_REPO} /plugins-local/src/${PLUGIN_MODULE} \
+      --depth 1 --single-branch --branch ${PLUGIN_RELEASE_TAG}
+
+FROM traefik:v2.6.1
+COPY --from=builder /plugins-local /plugins-local

--- a/Dockerfile.traefik
+++ b/Dockerfile.traefik
@@ -2,7 +2,7 @@
 FROM alpine:3 as builder
 ARG PLUGIN_MODULE=github.com/SwissDataScienceCenter/cookiefilter
 ARG PLUGIN_GIT_REPO=https://github.com/SwissDataScienceCenter/cookiefilter.git
-ARG PLUGIN_RELEASE_TAG=0.0.1
+ARG PLUGIN_RELEASE_TAG=0.0.2
 RUN apk add --update git && \
     git clone ${PLUGIN_GIT_REPO} /plugins-local/src/${PLUGIN_MODULE} \
       --depth 1 --single-branch --branch ${PLUGIN_RELEASE_TAG}

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -14,3 +14,7 @@ charts:
         # Dockerfile path relative to chartpress.yaml
         dockerfilePath: Dockerfile
         valuesPath: image.auth
+      traefik:
+        contextPath: .
+        dockerfilePath: Dockerfile.traefik
+        valuesPath: traefik.image

--- a/helm-chart/renku-gateway/templates/configmap.yaml
+++ b/helm-chart/renku-gateway/templates/configmap.yaml
@@ -85,7 +85,7 @@ data:
 
         [http.routers.renku]
           entryPoints = ["web"]
-          Middlewares = ["auth-renku", "common"]
+          Middlewares = ["common"]
           Rule = "PathPrefix(`{{ printf "/%s/renku" .Values.gatewayServicePrefix | clean }}`)"
           Service = "core"
 
@@ -115,12 +115,16 @@ data:
           replacement = "{{(include "gateway.protocol" .)}}://${1}/${2}"
 
         [http.middlewares.common.chain]
-          middlewares = ["noCookies", "api"{{if .Values.gateway.allowOrigin }}{{", \"cors\""}}{{- end}}]
+          middlewares = ["cookiefilter", "api"{{if .Values.gateway.allowOrigin }}{{", \"cors\""}}{{- end}}]
         {{ if .Values.gateway.allowOrigin }}
         [http.middlewares.cors.headers]
           accessControlAllowOriginList  = [{{- range .Values.gateway.allowOrigin}} {{- . | quote }},{{end}}]
           addVaryHeader = true
         {{ end }}
+
+        [http.middlewares.cookiefilter.plugin.cookiefilter]
+          keepCookies = {{ concat .Values.keepCookies (list "stickyCoreIngressCookie") | toJson }}
+
         [http.middlewares.noCookies.headers]
           [http.middlewares.noCookies.headers.customRequestHeaders]
             Cookie = ""
@@ -211,7 +215,7 @@ data:
         [http.services.core.loadBalancer]
           passHostHeader = false
           [[http.services.core.loadBalancer.servers]]
-          url = "{{ printf "http://%s-core" .Release.Name }}"
+          url = "{{ printf "%s://%s/api/renku" (include "gateway.protocol" .) .Values.global.renku.domain }}"
 
         # We need a default backend, should never be hit
         [http.services.default.loadBalancer]

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -67,8 +67,7 @@ global:
     image:
       repository: renku/certificates
       tag: "0.0.2"
-    customCAs:
-      []
+    customCAs: []
       # - secret:
 
   ## Specify the information required to connect to a redis instance.
@@ -130,8 +129,7 @@ service:
   type: ClusterIP
   port: 80
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -191,6 +189,10 @@ oldGitLabLogout: false
 # trigger a logout from GitLab.
 logoutGitLabUponRenkuLogout: true
 
+# By default the gateway will strip all cookies. If specific cookies should be
+# kept (i.e. for sticky ingress routing) specify them here
+keepCookies: []
+
 # sentry configuration
 sentry:
   enabled: false
@@ -203,6 +205,9 @@ ingress:
   enabled:
 
 traefik:
+  image:
+    name: renku/traefik
+    tag: latest
   anchors:
     nameOverride: &nameOverride renku-traefik
   affinity:
@@ -225,16 +230,17 @@ traefik:
     minReplicas: 2
     maxReplicas: 10
     metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: 60
-    - type: Resource
-      resource:
-        name: memory
-        targetAverageUtilization: 60
+      - type: Resource
+        resource:
+          name: cpu
+          targetAverageUtilization: 60
+      - type: Resource
+        resource:
+          name: memory
+          targetAverageUtilization: 60
   additionalArguments:
     - "--providers.file.directory=/config"
+    - "--experimental.localPlugins.cookiefilter.moduleName=github.com/SwissDataScienceCenter/cookiefilter"
     ## If using custom/self-signed CA certificates uncomment the value below and 
     ## adjust the volumes section below
     # - "--serversTransport.rootCAs=/ca-certs/foo.crt,/ca-certs/bar.crt"
@@ -252,7 +258,7 @@ traefik:
           defaultmode: keep
         headers:
           defaultmode: keep
-          names: 
+          names:
             Authorization: redact
             Cookie: redact
             Renku-Auth-Access-Token: redact
@@ -289,7 +295,7 @@ traefik:
   service:
     enabled: true
     type: ClusterIP
-  volumes: 
+  volumes:
     - name: renku-traefik-config
       mountPath: "/config"
       type: configMap

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -209,7 +209,7 @@ ingress:
 traefik:
   image:
     name: renku/traefik
-    tag: latest
+    tag: 0.0.1-set-by-chartpress
   anchors:
     nameOverride: &nameOverride renku-traefik
   affinity:


### PR DESCRIPTION
This is required for https://github.com/SwissDataScienceCenter/renku-python/pull/3178.

I created a really small and simple middleware plugin for traefik: https://github.com/SwissDataScienceCenter/cookiefilter. 

It follows the [traefik example](https://github.com/traefik/plugindemo) and [docs](https://plugins.traefik.io/create) on creating a custom plugin. This is required because the middlewares that come included in traefik cannot conditionally filter cookies. What we currently have in place (and the only thing remotely close to what we need) is [this](https://doc.traefik.io/traefik/middlewares/http/headers/) which simply can remove a specific header. So we currently use this middleware to remove all cookies but we cannot selectively keep some of them.

In order for sticky sessions to work we have to not strip the sticky session cookies. That is why this plugin was needed.

And the only way to add a custom plugin to a traefik helm chart (without switching to the paid version) is to rebuild the image with the plugin in it.

/deploy #persist renku-core=feat-scale-core-service renku-ui=update-renku-version-endpoint extra-values=core.ingress.hosts[0].host=renku-ci-gw-602.dev.renku.ch,core.ingress.tls[0].secretName=renku-ci-gw-602-ch-tls,core.ingress.tls[0].hosts[0]=renku-ci-gw-602.dev.renku.ch