### PR TITLE
chore: do not show debug logs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,7 +55,7 @@ if VSCODE_DEBUG:
 app = Flask(__name__)
 
 # We activate all log levels and prevent logs from showing twice.
-app.logger.setLevel(logging.INFO)
+app.logger.setLevel(logging.DEBUG if config.DEBUG else logging.INFO)
 app.logger.propagate = False
 
 # Initialize Sentry when required

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,7 +55,7 @@ if VSCODE_DEBUG:
 app = Flask(__name__)
 
 # We activate all log levels and prevent logs from showing twice.
-app.logger.setLevel(logging.DEBUG)
+app.logger.setLevel(logging.INFO)
 app.logger.propagate = False
 
 # Initialize Sentry when required

--- a/app/auth/gitlab_auth.py
+++ b/app/auth/gitlab_auth.py
@@ -53,9 +53,6 @@ class GitlabUserToken:
             r"bearer (?P<token>.+)", headers.get("Authorization", ""), re.IGNORECASE
         )
         if m:
-            # current_app.logger.debug(
-            #    'outgoing headers: {}'.format(json.dumps(headers)
-            # )
             access_token = m.group("token")
             redis_key = get_redis_key_from_token(access_token, key_suffix=GL_SUFFIX)
             gitlab_oauth_client = current_app.store.get_oauth_client(redis_key)

--- a/app/auth/web.py
+++ b/app/auth/web.py
@@ -68,7 +68,7 @@ def get_valid_token(headers):
     keycloak_oidc_client = current_app.store.get_oauth_client(redis_key)
     if hasattr(keycloak_oidc_client, "access_token"):
         return keycloak_oidc_client.access_token
-    current_app.logger.warning(
+    current_app.logger.debug(
         "The user does not have backend access tokens.",
         exc_info=True,
     )

--- a/app/config.py
+++ b/app/config.py
@@ -109,3 +109,5 @@ OLD_GITLAB_LOGOUT = os.environ.get("OLD_GITLAB_LOGOUT", "") == "true"
 LOGOUT_GITLAB_UPON_RENKU_LOGOUT = (
     os.environ.get("LOGOUT_GITLAB_UPON_RENKU_LOGOUT", "") == "true"
 )
+
+DEBUG = os.environ.get("DEBUG", "false") == "true"

--- a/helm-chart/renku-gateway/templates/deployment.yaml
+++ b/helm-chart/renku-gateway/templates/deployment.yaml
@@ -112,6 +112,8 @@ spec:
               value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENVIRONMENT
               value: {{ .Values.sentry.environment }}
+            - name: DEBUG
+              value: {{ .Values.global.debug | quote }}
             {{- include "certificates.env.python" . | nindent 12 }}
           volumeMounts:
             {{- include "certificates.volumeMounts.system" . | nindent 12 }}


### PR DESCRIPTION
There is just too much stuff in the logs. Most of it is really not useful.

This should cut back a lot on the logs.

For example getting the logs from renkulab I see:
```
[2022-10-27 19:54:34,395] DEBUG in __init__: Discovered redis master at 10.42.10.193:6379
[2022-10-27 19:54:34,400] DEBUG in __init__: Discovered redis master at 10.42.10.193:6379
[2022-10-27 19:54:34,517] DEBUG in __init__: Discovered redis master at 10.42.10.193:6379
[2022-10-27 19:54:34,527] WARNING in web: The user does not have backend access tokens.
NoneType: None
[2022-10-27 19:54:35,290] DEBUG in __init__: Discovered redis master at 10.42.10.193:6379
[2022-10-27 19:54:35,299] WARNING in web: The user does not have backend access tokens.
NoneType: None
[2022-10-27 19:54:35,789] DEBUG in __init__: Discovered redis master at 10.42.10.193:6379
[2022-10-27 19:54:35,800] WARNING in web: The user does not have backend access tokens.
NoneType: None
[2022-10-27 19:54:36,395] DEBUG in __init__: Discovered redis master at 10.42.10.193:6379
[2022-10-27 19:54:37,036] DEBUG in __init__: Discovered redis master at 10.42.10.193:6379
[2022-10-27 19:54:37,053] WARNING in web: The user does not have backend access tokens.
NoneType: None
[2022-10-27 19:54:37,323] DEBUG in __init__: Discovered redis master at 10.42.10.193:6379
[2022-10-27 19:54:37,334] WARNING in web: The user does not have backend access tokens.
NoneType: None
[2022-10-27 19:54:37,530] DEBUG in __init__: Discovered redis master at 10.42.10.193:6379
[2022-10-27 19:54:37,609] WARNING in web: The user does not have backend access tokens.
```

With this PR the warning about the user not having backend tokens and the redis master discovery will not be shown.