### PR TITLE
fix: handle expiring gitlab tokens

### DIFF
--- a/app/auth/cli_auth.py
+++ b/app/auth/cli_auth.py
@@ -35,7 +35,6 @@ from .utils import (
 
 blueprint = Blueprint("cli_auth", __name__, url_prefix="/auth/cli")
 
-CLI_SUFFIX = "cli_oauth_client"
 SCOPE = ["profile", "email", "openid"]
 
 
@@ -67,16 +66,18 @@ def login():
     return handle_login_request(
         provider_app,
         urljoin(current_app.config["HOST_NAME"], url_for("cli_auth.token")),
-        CLI_SUFFIX,
+        current_app.config["CLI_SUFFIX"],
         SCOPE,
     )
 
 
 @blueprint.route("/token")
 def token():
-    response, _ = handle_token_request(request, CLI_SUFFIX)
+    response, _ = handle_token_request(request, current_app.config["CLI_SUFFIX"])
 
-    client_redis_key = get_redis_key_from_session(key_suffix=CLI_SUFFIX)
+    client_redis_key = get_redis_key_from_session(
+        key_suffix=current_app.config["CLI_SUFFIX"]
+    )
     cli_nonce = session.get("cli_nonce")
     if cli_nonce:
         server_nonce = session.get("server_nonce")

--- a/app/auth/gitlab_auth.py
+++ b/app/auth/gitlab_auth.py
@@ -23,20 +23,23 @@ from urllib.parse import urljoin
 from flask import (
     Blueprint,
     current_app,
+    jsonify,
     redirect,
     render_template,
     request,
     url_for,
 )
 
+from ..config import GL_SUFFIX
+from .oauth_client import RenkuWebApplicationClient
 from .oauth_provider_app import GitLabProviderApp
 from .utils import (
     get_redis_key_from_token,
     handle_login_request,
     handle_token_request,
+    keycloak_authenticated,
 )
 
-GL_SUFFIX = "gl_oauth_client"
 
 blueprint = Blueprint("gitlab_auth", __name__, url_prefix="/auth/gitlab")
 
@@ -84,14 +87,14 @@ def login():
     return handle_login_request(
         provider_app,
         urljoin(current_app.config["HOST_NAME"], url_for("gitlab_auth.token")),
-        GL_SUFFIX,
+        current_app.config["GL_SUFFIX"],
         SCOPE,
     )
 
 
 @blueprint.route("/token")
 def token():
-    response, _ = handle_token_request(request, GL_SUFFIX)
+    response, _ = handle_token_request(request, current_app.config["GL_SUFFIX"])
     return response
 
 
@@ -108,3 +111,27 @@ def logout():
         response = render_template("gitlab_logout.html", logout_url=logout_url)
 
     return response
+
+
+@blueprint.route("/exchange", methods=["GET"])
+@keycloak_authenticated
+def exchange(*, sub, access_token):
+    """Exchange a keycloak JWT for a valid Gitlab oauth token."""
+    redis_key = get_redis_key_from_token(
+        access_token, key_suffix=current_app.config["GL_SUFFIX"]
+    )
+    # NOTE: getting the client from the redis store automatically refreshes if needed
+    gl_oauth_client: RenkuWebApplicationClient = current_app.store.get_oauth_client(
+        redis_key
+    )
+    return jsonify(
+        {
+            "git": {
+                "access_token": gl_oauth_client.access_token,
+                "expires_at": gl_oauth_client._expires_at,
+            },
+            "renku": {
+                "access_token": access_token,
+            },
+        }
+    )

--- a/app/auth/notebook_auth.py
+++ b/app/auth/notebook_auth.py
@@ -19,18 +19,20 @@
 import json
 import re
 from base64 import b64encode
+from typing import List
 
 from flask import current_app
 
 from .gitlab_auth import GL_SUFFIX
+from .oauth_client import RenkuWebApplicationClient
 from .utils import get_redis_key_from_token, get_or_set_keycloak_client
-from .web import KC_SUFFIX
+from ..config import KC_SUFFIX
 
 # TODO: This is a temporary implementation of the header interface defined in #404
 # TODO: that allowes first clients to transition.
 
 
-def get_git_credentials_header(git_oauth_clients):
+def get_git_credentials_header(git_oauth_clients: List[RenkuWebApplicationClient]):
     """
     Create the git authentication header as defined in #406
     (https://github.com/SwissDataScienceCenter/renku-gateway/issues/406)
@@ -42,6 +44,7 @@ def get_git_credentials_header(git_oauth_clients):
             # TODO: add this information to the provider_app and read it from there.
             "provider": "GitLab",
             "AuthorizationHeader": f"bearer {client.access_token}",
+            "AccessTokenExpiresAt": client._expires_at,
         }
         for client in git_oauth_clients
     }

--- a/app/auth/renku_auth.py
+++ b/app/auth/renku_auth.py
@@ -28,7 +28,7 @@ from .utils import (
     get_redis_key_from_token,
     get_or_set_keycloak_client,
 )
-from .web import KC_SUFFIX
+from ..config import KC_SUFFIX
 
 # TODO: We're using a class here only to have a uniform interface
 # with GitlabUserToken and JupyterhubUserToken. This should be refactored.

--- a/app/auth/utils.py
+++ b/app/auth/utils.py
@@ -18,13 +18,16 @@
 
 import hashlib
 import random
+import re
 import secrets
 import string
+from functools import wraps
 from urllib.parse import urljoin
 
 import jwt
-from flask import current_app, redirect, session, url_for
+from flask import current_app, redirect, request, session, url_for
 
+from ..config import KC_SUFFIX, KEYCLOAK_JWKS_CLIENT
 from .oauth_client import RenkuWebApplicationClient
 from .oauth_provider_app import KeycloakProviderApp
 
@@ -37,7 +40,7 @@ def decode_keycloak_jwt(token):
     return jwt.decode(
         token,
         current_app.config["OIDC_PUBLIC_KEY"],
-        algorithms=JWT_ALGORITHM,
+        algorithms=[JWT_ALGORITHM],
         audience=current_app.config["OIDC_CLIENT_ID"],
     )
 
@@ -102,6 +105,7 @@ def handle_token_request(request, key_suffix):
             urljoin(current_app.config["HOST_NAME"], url_for("web_auth.login_next"))
         )
     )
+
     return response, oauth_client
 
 
@@ -133,3 +137,58 @@ def get_or_set_keycloak_client(redis_key: str) -> RenkuWebApplicationClient:
         )
         current_app.store.set_oauth_client(redis_key, oauth_client)
     return oauth_client
+
+
+def keycloak_authenticated(f):
+    """Looks for a JWT in the Authorization header in the form of a bearer token.
+    Permits the request to proceed even if the JWT signature check is sucessful
+    but the token is expired. Injects the 'sub' claim of the JWT and the encoded
+    JWT in the function as a keyword arguments. The names for the arguments are
+    'sub' and 'access_token' for the sub-claim and access_token respectively."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        m = re.search(
+            r"^bearer (?P<token>.+)",
+            request.headers.get("Authorization", ""),
+            re.IGNORECASE,
+        )
+        if m:
+            access_token = m.group("token")
+            signing_key = KEYCLOAK_JWKS_CLIENT.get_signing_key_from_jwt(access_token)
+            try:
+                data = jwt.decode(
+                    access_token,
+                    key=signing_key.key,
+                    algorithms=[JWT_ALGORITHM],
+                    audience=current_app.config["OIDC_CLIENT_ID"],
+                )
+            except jwt.exceptions.ExpiredSignatureError:
+                # NOTE: This means that the signature of the token is valid. I.e.
+                # using the public signing key from keycloak we have confirmed that the
+                # token is exactly how keycloak published it and it has not been
+                # tampered with. What has happened however is that the "exp" claim in
+                # the token is past the current time. If the caller had a refresh
+                # token it could simply use it to get a new acces token. But because the
+                # caller does not have a refresh token then we use the gateway to
+                # perform the refresh.
+                data = jwt.decode(
+                    access_token,
+                    key=signing_key.key,
+                    algorithms=[JWT_ALGORITHM],
+                    audience=current_app.config["OIDC_CLIENT_ID"],
+                    options={"verify_exp": False},
+                )
+                redis_key = _get_redis_key(data["sub"], key_suffix=KC_SUFFIX)
+                # NOTE: getting the client from the redis store automatically refreshes
+                # the token if the token is expired.
+                kc_oauth_client: RenkuWebApplicationClient = (
+                    current_app.store.get_oauth_client(redis_key)
+                )
+                access_token = kc_oauth_client.access_token
+                if not access_token:
+                    raise Exception("Keycloak token cannot be refreshed")
+            return f(*args, **kwargs, sub=data["sub"], access_token=access_token)
+        raise Exception("Not authenticated")
+
+    return decorated

--- a/app/tests/test_proxy.py
+++ b/app/tests/test_proxy.py
@@ -23,8 +23,6 @@ import requests
 import responses
 
 from .. import app
-from ..auth.cli_auth import CLI_SUFFIX
-from ..auth.gitlab_auth import GL_SUFFIX
 from ..auth.oauth_client import RenkuWebApplicationClient
 from ..auth.oauth_provider_app import OAuthProviderApp
 from ..auth.oauth_redis import OAuthRedis
@@ -102,9 +100,9 @@ def test_gitlab_happyflow(client):
 
     app.store = OAuthRedis(hex_key=app.config["SECRET_KEY"])
 
-    set_dummy_oauth_client(access_token, CLI_SUFFIX)
+    set_dummy_oauth_client(access_token, app.config["CLI_SUFFIX"])
 
-    set_dummy_oauth_client("some_token", GL_SUFFIX)
+    set_dummy_oauth_client("some_token", app.config["GL_SUFFIX"])
 
     rv = client.get("/?auth=gitlab", headers=headers)
 

--- a/helm-chart/renku-gateway/templates/deployment.yaml
+++ b/helm-chart/renku-gateway/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: GITLAB_CLIENT_ID
               value: {{ .Values.gitlabClientId | default .Values.global.gateway.gitlabClientId | quote }}
             - name: KEYCLOAK_URL
-              value: {{ .Values.keycloakUrl | default (printf "%s://%s" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
+              value: {{ .Values.keycloakUrl | default (printf "%s://%s/auth" (include "gateway.protocol" .) .Values.global.renku.domain) | quote }}
               {{ if .Values.global.keycloak.realm }}
             - name: KEYCLOAK_REALM
               value: {{ .Values.global.keycloak.realm | quote }}


### PR DESCRIPTION

Related to: https://github.com/SwissDataScienceCenter/renku-notebooks/pull/1335

The changes are as follows:
- the gateway exposes a new endpoint at /gitlab/exchange
- this endpoint requires a keycloak JWT and when one it is provided it will fetch the gitlab oauth token, refresh it if needed and return it
- in addition to the gitlab token the gateway will accept a valid (i.e. signature-wise) but expired keycloak token and if this happens it will return to the caller a refreshed keycloak JWT.

This is required because the git proxy in the sessions need a way to refresh their gitlab tokens. But we do not feel comfortable adding refresh tokens in the sessions. This may not even be feasible as using the refresh token invalidates it. So in this case the session would get the refresh token from the gateway and if it used it before the gateway eventually does then the gateway's refresh token would be invalid. And the gateway would be "stuck" with an expired access_token and an expired refresh_token that cannot be used for anything. At this hypothetical point the gateway would also have no way (other than involving the user in a new login flow) to acquire a new valid refresh token.