### PR TITLE
fix: use offline access tokens for renku client

### DIFF
--- a/app/auth/web.py
+++ b/app/auth/web.py
@@ -44,7 +44,7 @@ from .utils import (
 
 blueprint = Blueprint("web_auth", __name__, url_prefix="/auth")
 
-SCOPE = ["profile", "email", "openid"]
+SCOPE = ["profile", "email", "openid", "offline_access"]
 
 
 def get_valid_token(headers):


### PR DESCRIPTION
This enables the renku client to keep using refresh tokens even after a user logs out. This feature exactly for what we are using it. Doing data backups or similar operations even after the user has logged out but on their behalf.

See https://www.keycloak.org/docs/15.1/server_admin/index.html#_offline-access

