### PR TITLE
chore: prep 0.19.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes
 
+## [0.19.0](https://github.com/SwissDataScienceCenter/renku-gateway/compare/0.18.1...0.19.0) (2023-03-31)
+
+
+### Features
+
+* **app:** sticky sessions middleware ([#630](https://github.com/SwissDataScienceCenter/renku-gateway/issues/630)) ([06ff27c](https://github.com/SwissDataScienceCenter/renku-gateway/commit/06ff27cbdc7ba7f5bc7cfbf235c6e643042faecd))
+* **app:** use golang echo as reverse proxy ([#623](https://github.com/SwissDataScienceCenter/renku-gateway/issues/623)) ([58e3cd0](https://github.com/SwissDataScienceCenter/renku-gateway/commit/58e3cd06b6da46cfd5f1d8ec929fee7db1873224))
+
+
+
 ## [0.18.1](https://github.com/SwissDataScienceCenter/renku-gateway/compare/0.18.0...0.18.1) (2023-02-24)
 
 ### Bug Fixes

--- a/cmd/revproxy/config.go
+++ b/cmd/revproxy/config.go
@@ -25,12 +25,19 @@ type metricsConfig struct {
 	Port    int  `mapstructure:"metrics_port"`
 }
 
+type rateLimits struct {
+	Enabled bool    `mapstructure:"rate_limits_enabled"`
+	Rate    float64 `mapstructure:"rate_limits_average"`
+	Burst   int     `mapstructure:"rate_limits_burst"`
+}
+
 type revProxyConfig struct {
 	RenkuBaseURL      *url.URL            `mapstructure:"renku_base_url"`
 	AllowOrigin       []string            `mapstructure:"allow_origin"`
 	ExternalGitlabURL *url.URL            `mapstructure:"external_gitlab_url"`
 	RenkuServices     renkuServicesConfig `mapstructure:",squash"`
 	Metrics           metricsConfig       `mapstructure:",squash"`
+	RateLimits        rateLimits          `mapstructure:",squash"`
 	Port              int
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/time v0.3.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
@@ -61,7 +62,6 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
-	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/helm-chart/renku-gateway/Chart.yaml
+++ b/helm-chart/renku-gateway/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "2.0"
 description: A Helm chart for the Renku gateway
 name: renku-gateway
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.18.1
+version: 0.19.0

--- a/helm-chart/renku-gateway/templates/deployment-revproxy.yaml
+++ b/helm-chart/renku-gateway/templates/deployment-revproxy.yaml
@@ -65,6 +65,12 @@ spec:
               value: {{ .Values.reverseProxy.metrics.enabled | quote }}
             - name: REVPROXY_METRICS_PORT
               value: {{ .Values.reverseProxy.metrics.port | quote }}
+            - name: REVPROXY_RATE_LIMITS_ENABLED
+              value: {{ .Values.rateLimits.general.enabled | quote }}
+            - name: REVPROXY_RATE_LIMITS_AVERAGE
+              value: {{ .Values.rateLimits.general.average | quote }}
+            - name: REVPROXY_RATE_LIMITS_BURST
+              value: {{ .Values.rateLimits.general.burst | quote }}
           volumeMounts:
             {{- include "certificates.volumeMounts.system" . | nindent 12 }}
           livenessProbe:

--- a/helm-chart/renku-gateway/templates/pdb.yaml
+++ b/helm-chart/renku-gateway/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if or (gt (int .Values.reverseProxy.replicaCount) 1) (and .Values.reverseProxy.autoscaling.enabled (gt (int .Values.reverseProxy.autoscaling.minReplicas) 1)) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "gateway.fullname" . }}-revproxy
+  labels:
+    app: {{ template "gateway.name" . }}-revproxy
+    chart: {{ template "gateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: 50%
+  selector:
+    matchLabels:
+      app: {{ template "gateway.name" . }}-revproxy
+      release: {{ .Release.Name }}
+{{- end }}

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -61,8 +61,6 @@ global:
   ## should have the .crt extension otherwise it is ignored. The
   ## keys across all secrets are mounted as files in one location so
   ## the keys across all secrets have to be unique.
-  ## In addition to this the certificates have to be seperately defined
-  ## in the Traefik section below for the Traefik Helm sub-chart.
   certificates:
     image:
       repository: renku/certificates
@@ -102,13 +100,12 @@ development: false
 
 ## To protect the backend services from an excessive amount of API calls
 ## issued by one client, one can enforce rate limits here. The limits apply
-## per UI client session (identified by the cookies). For an explanation of
-## the different values check out the rate limiting documentation of traefik
-## v2.0.
+## based on the IP address of the client.
 rateLimits:
-  ## General rate limit, applies to all /api calls combined.
+  ## General rate limit, applies to all calls combined.
   general:
-    period: 10s
+    enabled: false
+    ## average rate units are requests per second
     average: 20
     burst: 100
 
@@ -214,7 +211,7 @@ reverseProxy:
   metrics:
     enabled: true
     port: 8765
-  replicaCount: 1
+  replicaCount: 2
   podAnnotations: {}
   resources: {}
   autoscaling:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "renku-gateway"
-version = "0.18.1"
+version = "0.19.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 license = "Apache 2"


### PR DESCRIPTION
/deploy #persist

The first release of the gateway which does not use traefik as the reverse proxy.

I made sure the functionality around rate limits and things around scaling the app are setup properly. It seems that we have been ignoring the rate limits for a while now - most probably ever since we switched from using the traefik image to using the traefik helm chart.

Now the rate limits will be enforced and they will be enabled by default (as was originally intended). The value of the rate limits was set to 2 req/s (i.e. 20 requests / 10 seconds). I think this is too low so I kept the value of 20 which is 20 req/second. I think that 2 req/second is too low for some services like the ui-server.

EDIT: I removed the rate limiting by default because the ui server could potentially be blocked by this since it sends requests on behalf of each user. So as the number of users grow the ui server could theoretically reach a high number of requests.
