### PR TITLE
feat: add new /api/kg/webhooks path

### DIFF
--- a/cmd/revproxy/main.go
+++ b/cmd/revproxy/main.go
@@ -59,7 +59,9 @@ func setupServer(config revProxyConfig) *echo.Echo {
 	// Routing for Renku services
 	e.Group("/api/auth", logger, authSvcProxy)
 	e.Group("/api/notebooks", logger, notebooksAuth, noCookies, stripPrefix("/api"), notebooksProxy)
+	// /api/projects/:projectID/graph will is being deprecated in favour of /api/kg/webhooks, the old endpoint will remain for some time for backward compatibility
 	e.Group("/api/projects/:projectID/graph", logger, gitlabAuth, noCookies, kgProjectsGraphRewrites, webhookProxy)
+	e.Group("/api/kg/webhooks", logger, gitlabAuth, noCookies, stripPrefix("/api/kg/webhooks"), webhookProxy)
 	e.Group("/api/datasets", logger, noCookies, regexRewrite("^/api(.*)", "/knowledge-graph$1"), kgProxy)
 	e.Group("/api/kg", logger, gitlabAuth, noCookies, regexRewrite("^/api/kg(.*)", "/knowledge-graph$1"), kgProxy)
 	e.Group("/api/renku", logger, renkuAuth, noCookies, stripPrefix("/api"), coreProxy)

--- a/cmd/revproxy/main_test.go
+++ b/cmd/revproxy/main_test.go
@@ -334,6 +334,24 @@ func TestInternalSvcRoutes(t *testing.T) {
 			ExternalGitlab: false,
 			Expected:       TestResults{Path: "/gitlab/api/v4/projects/some.username%2Ftest-project", VisitedServerIDs: []string{"auth", "upstream"}},
 		},
+		{
+			Path:     "/api/kg/webhooks/projects/123456/events/status/something/else",
+			Expected: TestResults{Path: "/projects/123456/events/status/something/else", VisitedServerIDs: []string{"auth", "upstream"}},
+		},
+		{
+			Path:        "/api/kg/webhooks/projects/123456/events/status",
+			QueryParams: map[string]string{"test1": "value1", "test2": "value2"},
+			Expected:    TestResults{Path: "/projects/123456/events/status", VisitedServerIDs: []string{"auth", "upstream"}},
+		},
+		{
+			Path:     "/api/kg/webhooks/projects/123456/webhooks/something/else",
+			Expected: TestResults{Path: "/projects/123456/webhooks/something/else", VisitedServerIDs: []string{"auth", "upstream"}},
+		},
+		{
+			Path:        "/api/kg/webhooks/projects/123456/webhooks",
+			QueryParams: map[string]string{"test1": "value1", "test2": "value2"},
+			Expected:    TestResults{Path: "/projects/123456/webhooks", VisitedServerIDs: []string{"auth", "upstream"}},
+		},
 	}
 	for _, testCase := range testCases {
 		// Test names show up poorly in vscode if the name contains "/"


### PR DESCRIPTION
/deploy #persist

As discussed with @lorenzo-cavazzi it will be nice to have all requests going to the KG and its components to go through the `/kg` route. 

Currently the `/api/projects` path leads to Gitlab most of the time except in a few specific cases when it goes to the kg. With the addition of the new path this is not the case anymore. This makes the pathing and logic easier to follow and it reduces the changes of errors.