### PR TITLE
fix: redirect to None on login or logout

### DIFF
--- a/app/auth/web.py
+++ b/app/auth/web.py
@@ -30,6 +30,7 @@ from flask import (
     url_for,
 )
 
+from .. import config
 from .cli_auth import handle_cli_token_request
 from .oauth_provider_app import KeycloakProviderApp
 from .utils import (
@@ -107,7 +108,7 @@ def login_next():
 def login():
     """Log in with Keycloak."""
     session.clear()
-    session["ui_redirect_url"] = request.args.get("redirect_url")
+    session["ui_redirect_url"] = request.args.get("redirect_url", config.HOST_NAME)
 
     cli_nonce = request.args.get("cli_nonce")
     if cli_nonce:
@@ -213,7 +214,7 @@ def logout():
 
     return render_template(
         "redirect_logout.html",
-        redirect_url=request.args.get("redirect_url"),
+        redirect_url=request.args.get("redirect_url", config.HOST_NAME),
         logout_pages=logout_pages,
         len=len(logout_pages),
     )

--- a/app/config.py
+++ b/app/config.py
@@ -38,6 +38,7 @@ ANONYMOUS_SESSIONS_ENABLED = (
     os.environ.get("ANONYMOUS_SESSIONS_ENABLED", "false") == "true"
 )
 
+# NOTE: HOST_NAME is actually the full base renku URL: i.e. https://dev.renku.ch
 HOST_NAME = os.environ.get("HOST_NAME", "http://gateway.renku.build")
 
 if "GATEWAY_SECRET_KEY" not in os.environ and "pytest" not in sys.modules:


### PR DESCRIPTION
Fixes a bug where if the query parameter for the redirect is not passed in then the redirect points to `None`.

/deploy #persist