### PR TITLE
fix(chart): HPA for reverse proxy

### DIFF
--- a/helm-chart/renku-gateway/templates/hpa-revproxy.yaml
+++ b/helm-chart/renku-gateway/templates/hpa-revproxy.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.reverseProxy.autoscaling.enabled }}
+{{- if semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
+{{- else -}}
+apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "gateway.fullname" . }}-revproxy
@@ -20,12 +24,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.reverseProxy.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.reverseProxy.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.reverseProxy.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.reverseProxy.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.reverseProxy.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/helm-chart/renku-gateway/values.yaml
+++ b/helm-chart/renku-gateway/values.yaml
@@ -218,6 +218,6 @@ reverseProxy:
     enabled: false
     minReplicas: 2
     maxReplicas: 5
-    targetMemoryUtilizationPercentage:
-    targetCPUUtilizationPercentage:
+    targetMemoryUtilizationPercentage: 75
+    targetCPUUtilizationPercentage: 75
   updateStrategy: {}


### PR DESCRIPTION
The templating for the horizontal pod autoscaler was using a mix of apiVersion v1 and v2.

Now we use v2 and v2beta2 which are idential in terms of what we use from them and this covers any k8s version older than 1.12.

/deploy #persist extra-values=gateway.reverseProxy.autoscaling.enabled=true