### PR TITLE
chore: prep 0.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## [0.20.0](https://github.com/SwissDataScienceCenter/renku-gateway/compare/0.19.2...0.20.0) (2023-05-25)
+
+### Features
+
+* add new /api/kg/webhooks path ([#639](https://github.com/SwissDataScienceCenter/renku-gateway/issues/639)) ([80a001c](https://github.com/SwissDataScienceCenter/renku-gateway/commit/80a001cd92381fe56956701e8947d4268d955ba3))
+
+
 ## [0.19.2](https://github.com/SwissDataScienceCenter/renku-gateway/compare/0.19.1...0.19.2) (2023-04-20)
 
 ### Bug Fixes

--- a/helm-chart/renku-gateway/Chart.yaml
+++ b/helm-chart/renku-gateway/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "2.0"
 description: A Helm chart for the Renku gateway
 name: renku-gateway
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 0.19.2
+version: 0.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "renku-gateway"
-version = "0.19.2"
+version = "0.20.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 license = "Apache 2"


### PR DESCRIPTION
New release including a new authenticated path for KG webhooks

/deploy #persist
