### PR TITLE
fix(chart): duplicate env variable in revproxy

### DIFF
--- a/helm-chart/renku-gateway/templates/deployment-revproxy.yaml
+++ b/helm-chart/renku-gateway/templates/deployment-revproxy.yaml
@@ -65,8 +65,6 @@ spec:
               value: {{ printf "http://%s-gateway-auth" .Release.Name }}
             - name: REVPROXY_RENKU_SERVICES_CRC
               value: {{ printf "http://%s" .Values.global.crc.serviceName | quote }}
-            - name: REVPROXY_DEBUG
-              value: "false"
             - name: REVPROXY_PORT
               value: "8080"
             - name: REVPROXY_METRICS_ENABLED


### PR DESCRIPTION
This causes the helm upgrade to fail because of the duplicate environment variable.
