### PR TITLE
fix: return 404 on wrong core svc metadata version

### DIFF
--- a/cmd/revproxy/main.go
+++ b/cmd/revproxy/main.go
@@ -68,7 +68,7 @@ func setupServer(ctx context.Context, config revProxyConfig) *echo.Echo {
 	e.Group("/api/kg", logger, gitlabAuth, noCookies, regexRewrite("^/api/kg(.*)", "/knowledge-graph$1"), kgProxy)
 	e.Group("/api/data", logger, noCookies, crcProxy)
 
-	registerCoreSvcProxies(ctx, e, config, logger, renkuAuth, noCookies, regexRewrite(`^/api/renku(?:/\d+)?((/|\?).*)??$`, "/renku$1"))
+	registerCoreSvcProxies(ctx, e, config, logger, checkCoreServiceMetadataVersion(config.RenkuServices.CoreServicePaths), renkuAuth, noCookies, regexRewrite(`^/api/renku(?:/\d+)?((/|\?).*)??$`, "/renku$1"))
 
 	// Routes that end up proxied to Gitlab
 	if config.ExternalGitlabURL != nil {

--- a/cmd/revproxy/main_test.go
+++ b/cmd/revproxy/main_test.go
@@ -158,16 +158,18 @@ func ParametrizedRouteTest(scenario TestCase) func(*testing.T) {
 			assert.Equal(t, http.StatusOK, res.StatusCode)
 		}
 		assert.Len(t, reqs, len(scenario.Expected.VisitedServerIDs))
-		for ireq, req := range reqs {
-			assert.Equal(t, scenario.Expected.VisitedServerIDs[ireq], req.Header.Get(serverIDHeader))
+		if len(reqs) == len(scenario.Expected.VisitedServerIDs) {
+			for ireq, req := range reqs {
+				assert.Equal(t, scenario.Expected.VisitedServerIDs[ireq], req.Header.Get(serverIDHeader))
+			}
 		}
 		for hdrKey, hdrValue := range scenario.Expected.ResponseHeaders {
 			assert.Equal(t, hdrValue, res.Header.Get(hdrKey))
 		}
-		if scenario.Expected.Path != "" {
+		if scenario.Expected.Path != "" && len(reqs) > 0 {
 			assert.Equal(t, scenario.Expected.Path, reqs[len(reqs)-1].URL.EscapedPath())
 		}
-		if len(scenario.QueryParams) > 0 {
+		if len(scenario.QueryParams) > 0 && len(reqs) > 0  {
 			assert.Equal(t, reqURLQuery.Encode(), reqs[len(reqs)-1].URL.RawQuery)
 		}
 	}
@@ -245,6 +247,16 @@ func TestInternalSvcRoutes(t *testing.T) {
 			Path:        "/api/renku/10",
 			QueryParams: map[string]string{"test1": "value1", "test2": "value2"},
 			Expected:    TestResults{Path: "/renku", VisitedServerIDs: []string{"auth", "upstream"}},
+		},
+		{
+			Path:        "/api/renku/8",
+			QueryParams: map[string]string{"test1": "value1", "test2": "value2"},
+			Expected:    TestResults{Path: "/api/renku/8", Non200ResponseStatusCode: 404},
+		},
+		{
+			Path:        "/api/renku/7/10/something/else",
+			QueryParams: map[string]string{"test1": "value1", "test2": "value2"},
+			Expected:    TestResults{Path: "/api/renku/7/10/something/else", Non200ResponseStatusCode: 404},
 		},
 		{
 			Path:        "/api/renku/10/1.1/test",


### PR DESCRIPTION
/deploy #persist

closes https://github.com/SwissDataScienceCenter/renku-python/issues/3569