### PR TITLE
fix(proxy): properly redirect from /gitlab urls

### DIFF
--- a/cmd/revproxy/main.go
+++ b/cmd/revproxy/main.go
@@ -73,7 +73,7 @@ func setupServer(ctx context.Context, config revProxyConfig) *echo.Echo {
 	// Routes that end up proxied to Gitlab
 	if config.ExternalGitlabURL != nil {
 		// Redirect "old" style bundled /gitlab pathing if an external Gitlab is used
-		e.Group("/gitlab", logger, stripPrefix("/gitlab"), gitlabProxyHost, gitlabProxy)
+		e.Group("/gitlab", logger, gitlabRedirect(config.ExternalGitlabURL.Host))
 		e.Group("/api/graphql", logger, gitlabAuth, gitlabProxyHost, gitlabProxy)
 		e.Group("/api/direct", logger, stripPrefix("/api/direct"), gitlabProxyHost, gitlabProxy)
 		e.Group("/repos", logger, cliGitlabAuth, noCookies, stripPrefix("/repos"), gitlabProxyHost, gitlabProxy)

--- a/cmd/revproxy/main_test.go
+++ b/cmd/revproxy/main_test.go
@@ -146,6 +146,7 @@ func ParametrizedRouteTest(scenario TestCase) func(*testing.T) {
 		}
 		reqURL.RawQuery = reqURLQuery.Encode()
 		res, err := http.Get(reqURL.String())
+		assert.NoError(t, err)
 		reqs := requestTracker.getAllRequests()
 
 		// Assert the request was routed as expected

--- a/cmd/revproxy/middlewares.go
+++ b/cmd/revproxy/middlewares.go
@@ -172,3 +172,17 @@ func checkCoreServiceMetadataVersion(coreSvcPaths []string) echo.MiddlewareFunc 
 		}
 	}
 }
+
+// gitlabRedirect redirects from the old-style internal gitlab url to an external Gitlab instance
+func gitlabRedirect(newGitlabHost string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			oldURL := c.Request().URL
+			newURL := *oldURL
+			newURL.Host = newGitlabHost
+			newURL.Path = strings.TrimPrefix(newURL.Path, "/gitlab")
+			newURL.RawPath = strings.TrimPrefix(newURL.RawPath, "/gitlab")
+			return c.Redirect(http.StatusMovedPermanently, newURL.String())
+		}
+	}
+}


### PR DESCRIPTION
The redirects for gitlab were originally implemented when we had traefik. When we migrated the redirect was not correctly setup. This should fix that.