### PR TITLE
chore: use same scopes as uiserver

### DIFF
--- a/app/auth/web.py
+++ b/app/auth/web.py
@@ -44,7 +44,7 @@ from .utils import (
 
 blueprint = Blueprint("web_auth", __name__, url_prefix="/auth")
 
-SCOPE = ["profile", "email", "openid", "offline_access"]
+SCOPE = ["profile", "email", "openid", "offline_access", "microprofile-jwt"]
 
 
 def get_valid_token(headers):


### PR DESCRIPTION
It seems that roles are not shown in id tokens that are passed to some services.

But we need the roles to tell if someone is and admin or not. I think this should make the roles show up.

/deploy renku-data-services=main renku=release-0.52.x