### PR TITLE
feat!: do not strip 'api' from the search service path

### DIFF
--- a/cmd/revproxy/main.go
+++ b/cmd/revproxy/main.go
@@ -75,7 +75,7 @@ func setupServer(ctx context.Context, config revProxyConfig) *echo.Echo {
 	e.Group("/api/datasets", logger, noCookies, regexRewrite("^/api(.*)", "/knowledge-graph$1"), kgProxy)
 	e.Group("/api/kg", logger, gitlabAuth, noCookies, regexRewrite("^/api/kg(.*)", "/knowledge-graph$1"), kgProxy)
 	e.Group("/api/data", logger, dataAuth, noCookies, dataServiceProxy)
-	e.Group("/api/search", logger, searchAuth, noCookies, stripPrefix("/api"), searchProxy)
+	e.Group("/api/search", logger, searchAuth, noCookies, searchProxy)
 	// /api/kc is used only by the ui and no one else, will be removed when the gateway is in charge of user sessions
 	e.Group("/api/kc", logger, stripPrefix("/api/kc"), keycloakProxyHost, keycloakProxy)
 

--- a/cmd/revproxy/main_test.go
+++ b/cmd/revproxy/main_test.go
@@ -226,11 +226,11 @@ func TestInternalSvcRoutes(t *testing.T) {
 		},
 		{
 			Path:     "/api/search/test/acceptedAuth",
-			Expected: TestResults{Path: "/search/test/acceptedAuth", VisitedServerIDs: []string{"auth", "upstream"}},
+			Expected: TestResults{Path: "/api/search/test/acceptedAuth", VisitedServerIDs: []string{"auth", "upstream"}},
 		},
 		{
 			Path:     "/api/search",
-			Expected: TestResults{Path: "/search", VisitedServerIDs: []string{"auth", "upstream"}},
+			Expected: TestResults{Path: "/api/search", VisitedServerIDs: []string{"auth", "upstream"}},
 		},
 		{
 			Path:     "/api/projects/123456/graph/status/something/else",


### PR DESCRIPTION
This is a breaking change it requires the search service and UI to adapt to it.