### PR TITLE
feat: add renku refresh token for data service

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -23,6 +23,9 @@ jobs:
       renku-graph: ${{ steps.deploy-comment.outputs.renku-graph}}
       renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
       renku-ui: ${{ steps.deploy-comment.outputs.renku-ui}}
+      renku-data-services: ${{ steps.deploy-comment.outputs.renku-data-services}}
+      amalthea: ${{ steps.deploy-comment.outputs.amalthea}}
+      amalthea-sessions: ${{ steps.deploy-comment.outputs.amalthea-sessions}}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
@@ -63,6 +66,9 @@ jobs:
           renku_graph: "${{ needs.check-deploy.outputs.renku-graph }}"
           renku_notebooks: "${{ needs.check-deploy.outputs.renku-notebooks }}"
           renku_ui: "${{ needs.check-deploy.outputs.renku-ui }}"
+          renku_data_services: "${{ needs.check-deploy.outputs.renku-data-services }}"
+          amalthea: "${{ needs.check-deploy.outputs.amalthea }}"
+          amalthea_sessions: "${{ needs.check-deploy.outputs.amalthea-sessions }}"
           extra_values: "${{ needs.check-deploy.outputs.extra-values }}"
       - name: Check existing renkubot comment
         uses: peter-evans/find-comment@v1

--- a/internal/revproxy/main.go
+++ b/internal/revproxy/main.go
@@ -122,7 +122,7 @@ func (r *Revproxy) initializeAuth() error {
 	if err != nil {
 		return err
 	}
-	r.dataGitlabAccessTokenAuth, err = NewAuth(AuthWithSessionStore(r.sessions), WithTokenType(models.AccessTokenType), WithProviderID("gitlab"), InjectInHeader("Gitlab-Access-Token"))
+	r.dataGitlabAccessTokenAuth, err = NewAuth(AuthWithSessionStore(r.sessions), WithTokenType(models.AccessTokenType), WithProviderID("gitlab"), WithTokenInjector(dataServiceGitlabAccessTokenInjector))
 	if err != nil {
 		return err
 	}

--- a/internal/revproxy/main.go
+++ b/internal/revproxy/main.go
@@ -74,7 +74,7 @@ func (r *Revproxy) RegisterHandlers(e *echo.Echo, commonMiddlewares ...echo.Midd
 	e.Group("/api/kg/webhooks", append(commonMiddlewares, gitlabToken, noCookies, stripPrefix("/api/kg/webhooks"), webhookProxy)...)
 	e.Group("/api/datasets", append(commonMiddlewares, noCookies, regexRewrite("^/api(.*)", "/knowledge-graph$1"), kgProxy)...)
 	e.Group("/api/kg", append(commonMiddlewares, gitlabToken, noCookies, regexRewrite("^/api/kg(.*)", "/knowledge-graph$1"), kgProxy)...)
-	e.Group("/api/data", append(commonMiddlewares, renkuAccessToken, dataGitlabAccessToken, noCookies, dataServiceProxy)...)
+	e.Group("/api/data", append(commonMiddlewares, renkuAccessToken, dataGitlabAccessToken, notebooksRenkuRefreshToken, notebooksAnonymousID(r.sessions), noCookies, dataServiceProxy)...)
 	e.Group("/api/search", append(commonMiddlewares, renkuAccessToken, notebooksRenkuIDToken, notebooksAnonymousID(r.sessions), noCookies, searchProxy)...)
 	// /api/kc is used only by the ui and no one else, will be removed when the gateway is in charge of user sessions
 	e.Group("/api/kc", append(commonMiddlewares, stripPrefix("/api/kc"), renkuAccessToken, keycloakProxyHost, keycloakProxy)...)

--- a/internal/revproxy/main_test.go
+++ b/internal/revproxy/main_test.go
@@ -391,7 +391,7 @@ func TestInternalSvcRoutes(t *testing.T) {
 					"Renku-Auth-Id-Token":      "",
 					"Renku-Auth-Access-Token":  "",
 					"Renku-Auth-Refresh-Token": "",
-					"Renku-Auth-Anon-Id":       "sessionID",
+					"Renku-Auth-Anon-Id":       "anon-sessionID",
 				}},
 			},
 			Sessions: []models.Session{
@@ -449,7 +449,7 @@ func TestInternalSvcRoutes(t *testing.T) {
 					"Renku-Auth-Id-Token":      "",
 					"Renku-Auth-Access-Token":  "",
 					"Renku-Auth-Refresh-Token": "",
-					"Renku-Auth-Anon-Id":       "sessionID",
+					"Renku-Auth-Anon-Id":       "anon-sessionID",
 				}},
 			},
 			Sessions: []models.Session{
@@ -669,7 +669,7 @@ func TestInternalSvcRoutes(t *testing.T) {
 					"Gitlab-Access-Token":            "",
 					"Gitlab-Access-Token-Expires-At": "",
 					"Renku-Auth-Refresh-Token":       "",
-					"Renku-Auth-Anon-Id":             "sessionID",
+					"Renku-Auth-Anon-Id":             "anon-sessionID",
 				}},
 			},
 		},

--- a/internal/revproxy/main_test.go
+++ b/internal/revproxy/main_test.go
@@ -113,6 +113,12 @@ func tokenProviderID(id string) tokenOption {
 	}
 }
 
+func tokenExpiresAt(val time.Time) tokenOption {
+	return func(t *models.AuthToken) {
+		t.ExpiresAt = val
+	}
+}
+
 func newTestToken(tokenType models.OauthTokenType, options ...tokenOption) models.AuthToken {
 	token := models.AuthToken{
 		Type:      tokenType,
@@ -632,6 +638,7 @@ func TestInternalSvcRoutes(t *testing.T) {
 					tokenID("gitlab:otherToken"),
 					tokenPlainValue("gitlabAccessTokenValue"),
 					tokenProviderID("gitlab"),
+					tokenExpiresAt(time.Unix(16746525971, 0)),
 				),
 			},
 			Sessions: []models.Session{
@@ -642,10 +649,11 @@ func TestInternalSvcRoutes(t *testing.T) {
 				Path:             "/api/data/user",
 				VisitedServerIDs: []string{"upstream"},
 				UpstreamRequestHeaders: []map[string]string{{
-					echo.HeaderAuthorization:   "Bearer accessTokenValue",
-					"Gitlab-Access-Token":      "gitlabAccessTokenValue",
-					"Renku-Auth-Refresh-Token": "refreshTokenValue",
-					"Renku-Auth-Anon-Id":       "",
+					echo.HeaderAuthorization:         "Bearer accessTokenValue",
+					"Gitlab-Access-Token":            "gitlabAccessTokenValue",
+					"Gitlab-Access-Token-Expires-At": "16746525971",
+					"Renku-Auth-Refresh-Token":       "refreshTokenValue",
+					"Renku-Auth-Anon-Id":             "",
 				}},
 			},
 		},
@@ -657,10 +665,11 @@ func TestInternalSvcRoutes(t *testing.T) {
 				Path:             "/api/data/sessions",
 				VisitedServerIDs: []string{"upstream"},
 				UpstreamRequestHeaders: []map[string]string{{
-					echo.HeaderAuthorization:   "",
-					"Gitlab-Access-Token":      "",
-					"Renku-Auth-Refresh-Token": "",
-					"Renku-Auth-Anon-Id":       "sessionID",
+					echo.HeaderAuthorization:         "",
+					"Gitlab-Access-Token":            "",
+					"Gitlab-Access-Token-Expires-At": "",
+					"Renku-Auth-Refresh-Token":       "",
+					"Renku-Auth-Anon-Id":             "sessionID",
 				}},
 			},
 		},

--- a/internal/revproxy/middlewares.go
+++ b/internal/revproxy/middlewares.go
@@ -252,7 +252,10 @@ func notebooksAnonymousID(sessions *sessions.SessionStore) echo.MiddlewareFunc {
 			if err != nil {
 				return err
 			}
-			c.Request().Header.Set("Renku-Auth-Anon-Id", session.ID)
+			// NOTE: The anonymous session ID must start with a letter, otherwise when we use it to create sessions in k8s
+			// things fail because a label value must start with a letter. That is why we add `anon-` here to the value.
+			// Note that valid values for a label in k8s are [a-zA-Z0-9], also -_. and it must start with a letter.
+			c.Request().Header.Set("Renku-Auth-Anon-Id", "anon-" + session.ID)
 			return next(c)
 		}
 	}


### PR DESCRIPTION
Also adds the anonymous user ID. All of this is required to be able to launch sessions with the new operator for the data service.

/deploy