### PR TITLE
fix: inject renku access token for search

### DIFF
--- a/internal/revproxy/main.go
+++ b/internal/revproxy/main.go
@@ -75,7 +75,7 @@ func (r *Revproxy) RegisterHandlers(e *echo.Echo, commonMiddlewares ...echo.Midd
 	e.Group("/api/datasets", append(commonMiddlewares, noCookies, regexRewrite("^/api(.*)", "/knowledge-graph$1"), kgProxy)...)
 	e.Group("/api/kg", append(commonMiddlewares, gitlabToken, noCookies, regexRewrite("^/api/kg(.*)", "/knowledge-graph$1"), kgProxy)...)
 	e.Group("/api/data", append(commonMiddlewares, renkuAccessToken, dataGitlabAccessToken, noCookies, dataServiceProxy)...)
-	e.Group("/api/search", append(commonMiddlewares, notebooksRenkuIDToken, notebooksAnonymousID(r.sessions), noCookies, searchProxy)...)
+	e.Group("/api/search", append(commonMiddlewares, renkuAccessToken, noCookies, searchProxy)...)
 	// /api/kc is used only by the ui and no one else, will be removed when the gateway is in charge of user sessions
 	e.Group("/api/kc", append(commonMiddlewares, stripPrefix("/api/kc"), renkuAccessToken, keycloakProxyHost, keycloakProxy)...)
 

--- a/internal/revproxy/main.go
+++ b/internal/revproxy/main.go
@@ -75,7 +75,7 @@ func (r *Revproxy) RegisterHandlers(e *echo.Echo, commonMiddlewares ...echo.Midd
 	e.Group("/api/datasets", append(commonMiddlewares, noCookies, regexRewrite("^/api(.*)", "/knowledge-graph$1"), kgProxy)...)
 	e.Group("/api/kg", append(commonMiddlewares, gitlabToken, noCookies, regexRewrite("^/api/kg(.*)", "/knowledge-graph$1"), kgProxy)...)
 	e.Group("/api/data", append(commonMiddlewares, renkuAccessToken, dataGitlabAccessToken, noCookies, dataServiceProxy)...)
-	e.Group("/api/search", append(commonMiddlewares, renkuAccessToken, noCookies, searchProxy)...)
+	e.Group("/api/search", append(commonMiddlewares, renkuAccessToken, notebooksRenkuIDToken, notebooksAnonymousID(r.sessions), noCookies, searchProxy)...)
 	// /api/kc is used only by the ui and no one else, will be removed when the gateway is in charge of user sessions
 	e.Group("/api/kc", append(commonMiddlewares, stripPrefix("/api/kc"), renkuAccessToken, keycloakProxyHost, keycloakProxy)...)
 

--- a/internal/revproxy/main_test.go
+++ b/internal/revproxy/main_test.go
@@ -457,7 +457,7 @@ func TestInternalSvcRoutes(t *testing.T) {
 				Path:             "/api/search/test/acceptedAuth",
 				VisitedServerIDs: []string{"upstream"},
 				UpstreamRequestHeaders: []map[string]string{{
-					echo.HeaderAuthorization:   "",
+					echo.HeaderAuthorization:   "Bearer accessTokenValue",
 					"Renku-Auth-Id-Token":      "idTokenValue",
 					"Renku-Auth-Access-Token":  "",
 					"Renku-Auth-Refresh-Token": "",


### PR DESCRIPTION
Fixes #721.

/deploy #notest renku=release-0.57.0