### PR TITLE
feat: debug mode

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -43,8 +43,10 @@ func main() {
 		slog.Error("the config validation failed", "error", err)
 		os.Exit(1)
 	}
-	// TODO: configure log level
-	// logLevel.Set(slog.LevelDebug)
+	// Set log level to "debug" if activated
+	if gwConfig.DebugMode {
+		logLevel.Set(slog.LevelDebug)
+	}
 	// Setup
 	e := echo.New()
 	e.Pre(middleware.RequestID(), middleware.RemoveTrailingSlash(), revproxy.UiServerPathRewrite())

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -1,5 +1,6 @@
 # Example values for configuration
 runningEnvironment: production
+debugMode: false
 server:
   port: 8080
   allowOrigin: []

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -24,6 +24,7 @@ func (r RedactedString) MarshalBinary() ([]byte, error) {
 
 type Config struct {
 	RunningEnvironment
+	DebugMode  bool
 	Server     ServerConfig
 	Sessions   SessionConfig
 	Revproxy   RevproxyConfig


### PR DESCRIPTION
Add support for enabling debug logs from the gateway.

/deploy #notest
With debug: `<slash>deploy #notest renku=leafty/gateway-debug-mode extra-values=gateway.debug=true`