### PR TITLE
feat: replace notebooks with data service

### DIFF
--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -48,7 +48,7 @@ func TestInvalidLoginConfig(t *testing.T) {
 
 func TestInvalidRevproxyConfig(t *testing.T) {
 	config := getValidConfig(t)
-	config.Revproxy.RenkuServices.Notebooks = nil
+	config.Revproxy.RenkuServices.KG = nil
 
 	err := config.Validate()
 

--- a/internal/config/revproxy.go
+++ b/internal/config/revproxy.go
@@ -6,7 +6,6 @@ import (
 )
 
 type RenkuServicesConfig struct {
-	Notebooks   *url.URL
 	KG          *url.URL
 	Webhook     *url.URL
 	Core        CoreSvcConfig
@@ -30,9 +29,6 @@ type CoreSvcConfig struct {
 }
 
 func (r *RevproxyConfig) Validate() error {
-	if r.RenkuServices.Notebooks == nil {
-		return fmt.Errorf("the proxy config is missing the url to the notebook service")
-	}
 	if r.RenkuServices.KG == nil {
 		return fmt.Errorf("the proxy config is missing the url to the knowledge graph service")
 	}

--- a/internal/config/revproxy_test.go
+++ b/internal/config/revproxy_test.go
@@ -22,8 +22,6 @@ func getValidRevproxyConfig(t *testing.T) RevproxyConfig {
 }
 
 func getValidRenkuServicesConfig(t *testing.T) RenkuServicesConfig {
-	notebooksURL, err := url.Parse("http://notebooks")
-	require.NoError(t, err)
 	kgURL, err := url.Parse("http://kg")
 	require.NoError(t, err)
 	webhookURL, err := url.Parse("http://kg")
@@ -37,7 +35,6 @@ func getValidRenkuServicesConfig(t *testing.T) RenkuServicesConfig {
 	searchURL, err := url.Parse("http://ui")
 	require.NoError(t, err)
 	return RenkuServicesConfig{
-		Notebooks:   notebooksURL,
 		KG:          kgURL,
 		Webhook:     webhookURL,
 		DataService: dataServiceURL,
@@ -53,15 +50,6 @@ func TestValidRevproxyConfig(t *testing.T) {
 	err := config.Validate()
 
 	assert.NoError(t, err)
-}
-
-func TestInvalidNotebooksURL(t *testing.T) {
-	config := getValidRevproxyConfig(t)
-	config.RenkuServices.Notebooks = nil
-
-	err := config.Validate()
-
-	assert.ErrorContains(t, err, "the proxy config is missing the url to the notebook service")
 }
 
 func TestInvalidKGURL(t *testing.T) {

--- a/internal/revproxy/middlewares.go
+++ b/internal/revproxy/middlewares.go
@@ -215,6 +215,21 @@ func UiServerPathRewrite() echo.MiddlewareFunc {
 				c.Request().RequestURI = newUrl.String()
 				slog.Debug("PATH REWRITE", "message", "matched /ui-server/auth", "originalURL", originalURL, "newUrl", newUrl.String(), "requestID", utils.GetRequestID(c))
 			}
+			// For notebooks rewrite to go to the data service
+			if strings.HasPrefix(path, "/ui-server/api/notebooks") {
+				originalURL := c.Request().URL.String()
+				c.Request().URL.Path = strings.TrimPrefix(path, "/ui-server/api/notebooks")
+				c.Request().URL.RawPath = strings.TrimPrefix(c.Request().URL.RawPath, "/ui-server/api/notebooks")
+				c.Request().URL.Path = "/api/data/notebooks" + c.Request().URL.Path
+				c.Request().URL.RawPath = "/api/data/notebooks" + c.Request().URL.RawPath
+				newUrl, err := url.Parse(c.Request().URL.String())
+				if err != nil {
+					return err
+				}
+				c.Request().URL = newUrl
+				c.Request().RequestURI = newUrl.String()
+				slog.Debug("PATH REWRITE", "message", "matched /ui-server/api/notebooks", "originalURL", originalURL, "newUrl", newUrl.String(), "requestID", utils.GetRequestID(c))
+			}
 			// For all other endpoints the gateway will fully bypass the UI server routing things directly to the proper
 			// Renku component.
 			if strings.HasPrefix(path, "/ui-server/api") {


### PR DESCRIPTION
This routes all requests that go to the notebooks to the data service.

Tested the full suite of PRs for this in a separate PR on the renku repo. Also tested to make sure that sessions launched the old way still appear to anonymous and registered users.