### PR TITLE
ci: update acceptance tests action to run Renku v2 tests

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -1,5 +1,8 @@
 name: Acceptance tests
-
+permissions:
+  contents: read
+  pull-requests: read
+ 
 on:
   pull_request:
     types:
@@ -15,7 +18,8 @@ concurrency:
 
 jobs:
   check-deploy:
-    runs-on: ubuntu-22.04
+    name: Analyze deploy string
+    runs-on: ubuntu-24.04
     outputs:
       pr-contains-string: ${{ steps.deploy-comment.outputs.pr-contains-string }}
       renku: ${{ steps.deploy-comment.outputs.renku}}
@@ -30,35 +34,54 @@ jobs:
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.14.0
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.14.1
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
 
   deploy-pr:
-    needs: check-deploy
+    name: Deploy
+    runs-on: ubuntu-24.04
+    needs: [check-deploy]
+    permissions:
+      pull-requests: write
     if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true'
-    runs-on: ubuntu-22.04
     environment:
       name: renku-ci-gw-${{ github.event.number }}
+      url: https://renku-ci-gw-${{ github.event.number }}.dev.renku.ch
     steps:
-      - name: deploy-pr
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.14.0
+      - uses: actions/checkout@v4
+      - name: Find deplyoment url
+        uses: peter-evans/find-comment@v3
+        id: deploymentUrlMessage
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "RenkuBot"
+          body-includes: "You can access the deployment of this PR at"
+      - name: Create comment deployment url
+        if: steps.deploymentUrlMessage.outputs.comment-id == 0
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            You can access the deployment of this PR at https://renku-ci-gw-${{ github.event.number }}.dev.renku.ch
+      - name: Build and deploy
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.14.1
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
           KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
+          RANCHER_DEV_API_ENDPOINT: ${{ secrets.RANCHER_DEV_API_ENDPOINT }}
           RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
+          RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
           RENKU_RELEASE: renku-ci-gw-${{ github.event.number }}
+          RENKU_TESTS_ENABLED: true
           RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
           RENKU_VALUES: ${{ secrets.COMBINED_CHARTS_CI_RENKU_VALUES }}
           RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
-          RANCHER_DEV_API_ENDPOINT: ${{ secrets.RANCHER_DEV_API_ENDPOINT }}
-          RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
-          RENKU_ANONYMOUS_SESSIONS: true
-          RENKU_TESTS_ENABLED: true
           TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
           renku_gateway: "@${{ github.head_ref }}"
           renku: "${{ needs.check-deploy.outputs.renku }}"
@@ -70,41 +93,12 @@ jobs:
           amalthea: "${{ needs.check-deploy.outputs.amalthea }}"
           amalthea_sessions: "${{ needs.check-deploy.outputs.amalthea-sessions }}"
           extra_values: "${{ needs.check-deploy.outputs.extra-values }}"
-      - name: Check existing renkubot comment
-        uses: peter-evans/find-comment@v1
-        id: findcomment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "RenkuBot"
-          body-includes: "You can access the deployment of this PR at"
-      - name: Create comment pre deploy
-        if: steps.findcomment.outputs.comment-id == 0
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            You can access the deployment of this PR at https://renku-ci-gw-${{ github.event.number }}.dev.renku.ch
 
-  selenium-acceptance-tests:
-    needs: [check-deploy, deploy-pr]
-    runs-on: ubuntu-22.04
-    if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
-    steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.14.0
-        with:
-          kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
-          renku-release: renku-ci-gw-${{ github.event.number }}
-          gitlab-token: ${{ secrets.DEV_GITLAB_TOKEN }}
-          s3-results-access-key: ${{ secrets.ACCEPTANCE_TESTS_BUCKET_ACCESS_KEY }}
-          s3-results-secret-key: ${{ secrets.ACCEPTANCE_TESTS_BUCKET_SECRET_KEY }}
-          test-timeout-mins: 80
-    
-  cypress-acceptance-tests:
+  legacy-cypress-acceptance-tests:
+    name: Legacy Cypress tests
+    runs-on: ubuntu-24.04
     needs: [check-deploy, deploy-pr]
     if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
-    runs-on: ubuntu-22.04
-
     strategy:
       fail-fast: false
       matrix:
@@ -115,11 +109,38 @@ jobs:
           - testDatasets
           - useSession
           - checkWorkflows
-
+          - rstudioSession
+          - dashboardV2
     steps:
       - name: Extract Renku repository reference
         run: echo "RENKU_REFERENCE=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.14.0
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.14.1
+        with:
+          e2e-target: ${{ matrix.tests }}
+          renku-reference: ${{ env.RENKU_REFERENCE }}
+          renku-release: renku-ci-gw-${{ github.event.number }}
+          test-user-password: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
+    
+  cypress-acceptance-tests:
+    name: Cypress tests
+    runs-on: ubuntu-24.04
+    needs: [check-deploy, deploy-pr]
+    if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        tests:
+          - anonymousNavigation
+          - dashboardV2
+          - groupBasics
+          - projectBasics
+          - projectResources
+          - searchEntities
+          - sessionBasics
+    steps:
+      - name: Extract Renku repository reference
+        run: echo "RENKU_REFERENCE=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.14.1
         with:
           e2e-target: ${{ matrix.tests }}
           renku-reference: ${{ env.RENKU_REFERENCE }}
@@ -127,12 +148,30 @@ jobs:
           test-user-password: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
 
   cleanup:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-22.04
+    name: Cleanup
+    runs-on: ubuntu-24.04
+    needs: check-deploy
+    if: github.event.action == 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true'
+    permissions:
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v2
+      - name: Find deplyoment url
+        uses: peter-evans/find-comment@v3
+        id: deploymentUrlMessage
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "RenkuBot"
+          body-includes: "Tearing down the temporary RenkuLab deplyoment"
+      - name: Create comment deployment url
+        if: steps.deploymentUrlMessage.outputs.comment-id == 0
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Tearing down the temporary RenkuLab deplyoment for this PR.
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.14.0
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.14.1
         env:
           HELM_RELEASE_REGEX: "^renku-ci-gw-${{ github.event.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}


### PR DESCRIPTION
* Run the Cypress acceptance tests for v2
* Phase out Selenium acceptance tests
* Bump the Renku action to 1.14.1
* Add job names and adjust a few details

/deploy
