### PR TITLE
feat: add login product metrics

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -125,8 +125,6 @@ func main() {
 	}
 	revproxy.RegisterHandlers(e, gwMiddlewares...)
 	// Initialize login server
-	loginOptions := []login.LoginServerOption{login.WithConfig(gwConfig.Login), login.WithSessionStore(sessionStore), login.WithTokenStore(tokenStore)}
-
 	metricsClient, err := metrics.NewPosthogClient(gwConfig.Posthog)
 	if err != nil {
 		slog.Error("posthog client initializtion failed", "error", err)
@@ -135,8 +133,12 @@ func main() {
 	if metricsClient != nil {
 		defer metricsClient.Close()
 	}
-	loginOptions = append(loginOptions, login.WithMetricsClient(metricsClient))
-	loginServer, err := login.NewLoginServer(loginOptions...)
+	loginServer, err := login.NewLoginServer(
+		login.WithConfig(gwConfig.Login),
+		login.WithSessionStore(sessionStore),
+		login.WithTokenStore(tokenStore),
+		login.WithMetricsClient(metricsClient),
+	)
 	if err != nil {
 		slog.Error("login handlers initialization failed", "error", err)
 		os.Exit(1)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SwissDataScienceCenter/renku-gateway/internal/config"
 	"github.com/SwissDataScienceCenter/renku-gateway/internal/db"
 	"github.com/SwissDataScienceCenter/renku-gateway/internal/login"
+	"github.com/SwissDataScienceCenter/renku-gateway/internal/metrics"
 	"github.com/SwissDataScienceCenter/renku-gateway/internal/revproxy"
 	"github.com/SwissDataScienceCenter/renku-gateway/internal/sessions"
 	"github.com/SwissDataScienceCenter/renku-gateway/internal/tokenstore"
@@ -124,7 +125,18 @@ func main() {
 	}
 	revproxy.RegisterHandlers(e, gwMiddlewares...)
 	// Initialize login server
-	loginServer, err := login.NewLoginServer(login.WithConfig(gwConfig.Login), login.WithSessionStore(sessionStore), login.WithTokenStore(tokenStore))
+	loginOptions := []login.LoginServerOption{login.WithConfig(gwConfig.Login), login.WithSessionStore(sessionStore), login.WithTokenStore(tokenStore)}
+
+	if gwConfig.Posthog.Enabled {
+		metricsClient, err := metrics.NewPosthogClient(gwConfig.Posthog.ApiKey, gwConfig.Posthog.Host)
+		if err != nil {
+			slog.Error("posthog client initializtion failed", "error", err)
+			os.Exit(1)
+		}
+		loginOptions = append(loginOptions, login.WithMetricsClient(metricsClient))
+		defer metricsClient.Close()
+	}
+	loginServer, err := login.NewLoginServer(loginOptions...)
 	if err != nil {
 		slog.Error("login handlers initialization failed", "error", err)
 		os.Exit(1)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -127,15 +127,15 @@ func main() {
 	// Initialize login server
 	loginOptions := []login.LoginServerOption{login.WithConfig(gwConfig.Login), login.WithSessionStore(sessionStore), login.WithTokenStore(tokenStore)}
 
-	if gwConfig.Posthog.Enabled {
-		metricsClient, err := metrics.NewPosthogClient(gwConfig.Posthog.ApiKey, gwConfig.Posthog.Host, gwConfig.Posthog.Environment)
-		if err != nil {
-			slog.Error("posthog client initializtion failed", "error", err)
-			os.Exit(1)
-		}
-		loginOptions = append(loginOptions, login.WithMetricsClient(metricsClient))
+	metricsClient, err := metrics.NewPosthogClient(gwConfig.Posthog)
+	if err != nil {
+		slog.Error("posthog client initializtion failed", "error", err)
+		os.Exit(1)
+	}
+	if metricsClient != nil {
 		defer metricsClient.Close()
 	}
+	loginOptions = append(loginOptions, login.WithMetricsClient(metricsClient))
 	loginServer, err := login.NewLoginServer(loginOptions...)
 	if err != nil {
 		slog.Error("login handlers initialization failed", "error", err)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -128,7 +128,7 @@ func main() {
 	loginOptions := []login.LoginServerOption{login.WithConfig(gwConfig.Login), login.WithSessionStore(sessionStore), login.WithTokenStore(tokenStore)}
 
 	if gwConfig.Posthog.Enabled {
-		metricsClient, err := metrics.NewPosthogClient(gwConfig.Posthog.ApiKey, gwConfig.Posthog.Host)
+		metricsClient, err := metrics.NewPosthogClient(gwConfig.Posthog.ApiKey, gwConfig.Posthog.Host, gwConfig.Posthog.Environment)
 		if err != nil {
 			slog.Error("posthog client initializtion failed", "error", err)
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/oklog/ulid/v2 v2.1.0
+	github.com/posthog/posthog-go v1.3.3
 	github.com/redis/go-redis/v9 v9.4.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/posthog/posthog-go v1.3.3 h1:0b1JlfPDMKXGRgbTtqkSG6hsrlj8yW2tv2HS6Dn7wFk=
+github.com/posthog/posthog-go v1.3.3/go.mod h1:uYC2l1Yktc8E+9FAHJ9QZG4vQf/NHJPD800Hsm7DzoM=
 github.com/prometheus/client_golang v1.18.0 h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk=
 github.com/prometheus/client_golang v1.18.0/go.mod h1:T+GXkCk5wSJyOqMIzVgvvjFDlkOQntgjkJWKrN5txjA=
 github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -8,6 +8,7 @@ type Config struct {
 	Revproxy   RevproxyConfig
 	Login      LoginConfig
 	Redis      RedisConfig
+	Posthog    PosthogConfig
 	Monitoring MonitoringConfig
 }
 

--- a/internal/config/other.go
+++ b/internal/config/other.go
@@ -32,7 +32,7 @@ type RateLimits struct {
 
 type PosthogConfig struct {
 	Enabled     bool
-	ApiKey      string
+	ApiKey      RedactedString
 	Host        string
 	Environment string
 }

--- a/internal/config/other.go
+++ b/internal/config/other.go
@@ -31,7 +31,8 @@ type RateLimits struct {
 }
 
 type PosthogConfig struct {
-	Enabled bool
-	ApiKey  string
-	Host    string
+	Enabled     bool
+	ApiKey      string
+	Host        string
+	Environment string
 }

--- a/internal/config/other.go
+++ b/internal/config/other.go
@@ -29,3 +29,9 @@ type RateLimits struct {
 	Rate    float64
 	Burst   int
 }
+
+type PosthogConfig struct {
+	Enabled bool
+	ApiKey  string
+	Host    string
+}

--- a/internal/login/login_server.go
+++ b/internal/login/login_server.go
@@ -15,6 +15,7 @@ type LoginServer struct {
 	providerStore oidc.ClientStore
 	sessions      *sessions.SessionStore
 	tokenStore    models.TokenStoreInterface
+	metricsClient models.MetricsClientInterface
 }
 
 func (l *LoginServer) RegisterHandlers(server *echo.Echo, commonMiddlewares ...echo.MiddlewareFunc) {
@@ -54,6 +55,13 @@ func WithSessionStore(sessions *sessions.SessionStore) LoginServerOption {
 func WithTokenStore(store models.TokenStoreInterface) LoginServerOption {
 	return func(l *LoginServer) error {
 		l.tokenStore = store
+		return nil
+	}
+}
+
+func WithMetricsClient(client models.MetricsClientInterface) LoginServerOption {
+	return func(l *LoginServer) error {
+		l.metricsClient = client
 		return nil
 	}
 }

--- a/internal/login/login_server_routes.go
+++ b/internal/login/login_server_routes.go
@@ -218,6 +218,12 @@ func (l *LoginServer) nextAuthStep(
 		slog.Info("login completed", "requestID", utils.GetRequestID(c), "appRedirectURL", url)
 		// Save the session: ensure we save the session before sending redirects
 		l.sessions.Save(c)
+		// send product metrics
+		if l.metricsClient != nil {
+			if session, err := l.sessions.Get(c); err == nil {
+				l.metricsClient.UserLoggedIn(session.UserID)
+			}
+		}
 		return c.Redirect(http.StatusFound, url)
 	}
 	providerID := session.LoginSequence[0]

--- a/internal/metrics/posthog.go
+++ b/internal/metrics/posthog.go
@@ -26,6 +26,9 @@ func (p *PosthogMetricsClient) Close() {
 }
 
 func NewPosthogClient(c config.PosthogConfig) (*PosthogMetricsClient, error) {
+	if !c.Enabled {
+		return nil, nil
+	}
 	client, err := posthog.NewWithConfig(
 		string(c.ApiKey),
 		posthog.Config{
@@ -34,7 +37,7 @@ func NewPosthogClient(c config.PosthogConfig) (*PosthogMetricsClient, error) {
 		},
 	)
 	if err != nil {
-		return &PosthogMetricsClient{}, err
+		return nil, err
 	}
 
 	return &PosthogMetricsClient{posthogClient: client}, nil

--- a/internal/metrics/posthog.go
+++ b/internal/metrics/posthog.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 
+	"github.com/SwissDataScienceCenter/renku-gateway/internal/config"
 	"github.com/posthog/posthog-go"
 )
 
@@ -24,12 +25,12 @@ func (p *PosthogMetricsClient) Close() {
 	p.posthogClient.Close()
 }
 
-func NewPosthogClient(apiKey string, host string, environment string) (*PosthogMetricsClient, error) {
+func NewPosthogClient(c config.PosthogConfig) (*PosthogMetricsClient, error) {
 	client, err := posthog.NewWithConfig(
-		apiKey,
+		string(c.ApiKey),
 		posthog.Config{
-			Endpoint:               host,
-			DefaultEventProperties: posthog.Properties{"environment": environment},
+			Endpoint:               c.Host,
+			DefaultEventProperties: posthog.Properties{"environment": c.Environment},
 		},
 	)
 	if err != nil {

--- a/internal/metrics/posthog.go
+++ b/internal/metrics/posthog.go
@@ -24,11 +24,12 @@ func (p *PosthogMetricsClient) Close() {
 	p.posthogClient.Close()
 }
 
-func NewPosthogClient(apiKey string, host string) (*PosthogMetricsClient, error) {
+func NewPosthogClient(apiKey string, host string, environment string) (*PosthogMetricsClient, error) {
 	client, err := posthog.NewWithConfig(
 		apiKey,
 		posthog.Config{
-			Endpoint: host,
+			Endpoint:               host,
+			DefaultEventProperties: posthog.Properties{"environment": environment},
 		},
 	)
 	if err != nil {

--- a/internal/metrics/posthog.go
+++ b/internal/metrics/posthog.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+
+	"github.com/posthog/posthog-go"
+)
+
+type PosthogMetricsClient struct {
+	posthogClient posthog.Client
+}
+
+func (p *PosthogMetricsClient) anonymizeUser(userId string) string {
+	hash := md5.Sum([]byte(userId))
+	return hex.EncodeToString(hash[:])
+}
+
+func (p *PosthogMetricsClient) UserLoggedIn(userId string) error {
+	return p.posthogClient.Enqueue(posthog.Capture{DistinctId: p.anonymizeUser(userId), Event: "user_logged_in"})
+}
+
+func (p *PosthogMetricsClient) Close() {
+	p.posthogClient.Close()
+}
+
+func NewPosthogClient(apiKey string, host string) (*PosthogMetricsClient, error) {
+	client, err := posthog.NewWithConfig(
+		apiKey,
+		posthog.Config{
+			Endpoint: host,
+		},
+	)
+	if err != nil {
+		return &PosthogMetricsClient{}, err
+	}
+
+	return &PosthogMetricsClient{posthogClient: client}, nil
+}

--- a/internal/models/metrics.go
+++ b/internal/models/metrics.go
@@ -1,0 +1,5 @@
+package models
+
+type MetricsClientInterface interface {
+	UserLoggedIn(userId string) error
+}


### PR DESCRIPTION
Test of this:
![image](https://github.com/user-attachments/assets/ad92f2d6-1d69-4865-8c51-621210ea923f)
Note that the user id is the same for the posthog-python and posthog-go clients (data svc and gateway), so that all looks good