### PR TITLE
fix: do not crash the gateway when no metrics client is configured

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -133,12 +133,13 @@ func main() {
 	if metricsClient != nil {
 		defer metricsClient.Close()
 	}
-	loginServer, err := login.NewLoginServer(
-		login.WithConfig(gwConfig.Login),
+	loginOptions := []login.LoginServerOption{login.WithConfig(gwConfig.Login),
 		login.WithSessionStore(sessionStore),
-		login.WithTokenStore(tokenStore),
-		login.WithMetricsClient(metricsClient),
-	)
+		login.WithTokenStore(tokenStore)}
+	if metricsClient != nil {
+		loginOptions = append(loginOptions, login.WithMetricsClient(metricsClient))
+	}
+	loginServer, err := login.NewLoginServer(loginOptions...)
 	if err != nil {
 		slog.Error("login handlers initialization failed", "error", err)
 		os.Exit(1)

--- a/internal/login/login_server_routes.go
+++ b/internal/login/login_server_routes.go
@@ -219,7 +219,6 @@ func (l *LoginServer) nextAuthStep(
 		// Save the session: ensure we save the session before sending redirects
 		l.sessions.Save(c)
 		// send product metrics
-		slog.Error("hello", "metricsClient", l.metricsClient)
 		if l.metricsClient != nil {
 			if session, err := l.sessions.Get(c); err == nil {
 				l.metricsClient.UserLoggedIn(session.UserID)

--- a/internal/login/login_server_routes.go
+++ b/internal/login/login_server_routes.go
@@ -219,6 +219,7 @@ func (l *LoginServer) nextAuthStep(
 		// Save the session: ensure we save the session before sending redirects
 		l.sessions.Save(c)
 		// send product metrics
+		slog.Error("hello", "metricsClient", l.metricsClient)
 		if l.metricsClient != nil {
 			if session, err := l.sessions.Get(c); err == nil {
 				l.metricsClient.UserLoggedIn(session.UserID)


### PR DESCRIPTION
Fixes an issue when no metric client is defined.

This is one of go's very tricky quirks: a uninitialized interface will check against `== nil`, but an interface initialized with the `nil` value will NOT check against `== nil`. See: https://dave.cheney.net/2017/08/09/typed-nils-in-go-2.

Fixes this issue:

```
[PANIC RECOVER] runtime error: invalid memory address or nil pointer dereference goroutine 263 [running]:
main.main.Recover.RecoverWithConfig.func25.1.1()
	/go/pkg/mod/github.com/labstack/echo/v4@v4.11.4/middleware/recover.go:100 +0x150
panic({0x1af9a40?, 0x2f3ce60?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/SwissDataScienceCenter/renku-gateway/internal/metrics.(*PosthogMetricsClient).UserLoggedIn(0x0, {0xc000906810?, 0xc0003b6460?})
	/src/internal/metrics/posthog.go:21 +0x8d
github.com/SwissDataScienceCenter/renku-gateway/internal/login.(*LoginServer).nextAuthStep(0xc00027ea00, {0x2095080, 0xc0003b6460}, 0x5?)
	/src/internal/login/login_server_routes.go:224 +0x40b
github.com/SwissDataScienceCenter/renku-gateway/internal/login.(*LoginServer).GetCallback(0xc00027ea00, {0x2095080, 0xc0003b6460}, {{0x1db5b93?, 0x5?}, {0x10?, 0x199b940?}})
	/src/internal/login/login_server_routes.go:92 +0x3ac
github.com/SwissDataScienceCenter/renku-gateway/internal/login.(*ServerInterfaceWrapper).GetCallback(0xc0005a5120, {0x2095080, 0xc0003b6460})
	/src/internal/login/spec.gen.go:85 +0x225
github.com/SwissDataScienceCenter/renku-gateway/internal/login.NoCaching.func1({0x2095080, 0xc0003b6460})
	/src/internal/login/middlewares.go:21 +0x1a6
main.main.(*SessionStore).Middleware.func16.1({0x2095080, 0xc0003b6460})
	/src/internal/sessions/session_store.go:49 +0x24e
github.com/labstack/echo/v4/middleware.RequestLoggerConfig.ToMiddleware.func1.1({0x2095080, 0xc0003b6460})
	/go/pkg/mod/github.com/labstack/echo/v4@v4.11.4/middleware/request_logger.go:283 +0x16b
github.com/labstack/echo/v4.(*Echo).add.func1({0x2095080, 0xc0003b6460})
	/go/pkg/mod/github.com/labstack/echo/v4@v4.11.4/echo.go:582 +0x4b
github.com/labstack/echo-contrib/echoprometheus.MiddlewareConfig.ToMiddleware.func3.1({0x2095080, 0xc0003b6460})
	/go/pkg/mod/github.com/labstack/echo-contrib@v0.15.0/echoprometheus/prometheus.go:238 +0x282
main.main.Recover.RecoverWithConfig.func25.1({0x2095080?, 0xc0003b6460})
	/go/pkg/mod/github.com/labstack/echo/v4@v4.11.4/middleware/recover.go:131 +0x11d
github.com/labstack/echo/v4.(*Echo).ServeHTTP.func1({0x2095080, 0xc0003b6460})
	/go/pkg/mod/github.com/labstack/echo/v4@v4.11.4/echo.go:663 +0x127
main.main.UiServerPathRewrite.func5.1({0x2095080, 0xc0003b6460})
	/src/internal/revproxy/middlewares.go:247 +0xd62
main.main.RemoveTrailingSlash.RemoveTrailingSlashWithConfig.func24.1({0x2095080, 0xc0003b6460})
	/go/pkg/mod/github.com/labstack/echo/v4@v4.11.4/middleware/slash.go:118 +0x205
main.main.RequestID.RequestIDWithConfig.func23.1({0x2095080, 0xc0003b6460})
	/go/pkg/mod/github.com/labstack/echo/v4@v4.11.4/middleware/request_id.go:69 +0x112
github.com/labstack/echo/v4.(*Echo).ServeHTTP(0xc00003b680, {0x206dcf0?, 0xc00072a8c0}, 0xc00073ee00)
	/go/pkg/mod/github.com/labstack/echo/v4@v4.11.4/echo.go:669 +0x399
net/http.serverHandler.ServeHTTP({0xc00064e5d0?}, {0x206dcf0?, 0xc00072a8c0?}, 0x6?)
	/usr/local/go/src/net/http/server.go:2938 +0x8e
net/http.(*conn).serve(0xc0006543f0, {0x207b430, 0xc0004cf500})
	/usr/local/go/src/net/http/server.go:2009 +0x5f4
created by net/http.(*Server).Serve in goroutine 111
	/usr/local/go/src/net/http/server.go:3086 +0x5cb

goroutine 1 [chan receive, 1 minutes]:
main.main()
	/src/cmd/gateway/main.go:204 +0x2098

goroutine 55 [chan receive]:
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/go/pkg/mod/k8s.io/client-go@v0.29.0/tools/cache/shared_informer.go:967 +0x4b
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
	/go/pkg/mod/k8s.io/apimachinery@v0.29.0/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00013bf38?, {0x2062220, 0xc0004bc000}, 0x1, 0xc000058180)
	/go/pkg/mod/k8s.io/apimachinery@v0.29.0/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
	/go/pkg/mod/k8s.io/apimachinery@v0.29.0/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/pkg/mod/k8s.io/apimachinery@v0.29.0/pkg/util/wait/backoff.go:161
k8s.io/client-go/tools/cache.(*processorListener).run(0xc0006e0090)
	/go/pkg/mod/k8s.io/client-go@v0.29.0/tools/cache/shared_in
```

/deploy renku=release-0.68.0