### PR TITLE
feat: disable v1 svcs but keep internal gitlab

### DIFF
--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -24,6 +24,7 @@ sessions:
       authorizedParty: renku-cli
 revproxy:
   enableV1Services: true
+  enableInternalGitlab: true
   renkuBaseUrl: "https://renkulab.io"
   externalGitlabUrl:
   k8sNamespace:

--- a/internal/config/login.go
+++ b/internal/config/login.go
@@ -11,6 +11,7 @@ type TokenEncryptionConfig struct {
 }
 
 type LoginConfig struct {
+	EnableInternalGitlab        bool
 	EnableV1Services            bool
 	RenkuBaseURL                *url.URL
 	LoginRoutesBasePath         string
@@ -54,6 +55,9 @@ func (c LoginConfig) Validate(e RunningEnvironment) error {
 				return fmt.Errorf("provider %s cannot be configured without a cookie handler in production", k)
 			}
 		}
+	}
+	if c.EnableV1Services && !c.EnableInternalGitlab {
+		return fmt.Errorf("enabling V1 (legacy) services but disabling the internal Gitlab is not supported in the login config")
 	}
 	return nil
 }

--- a/internal/config/revproxy.go
+++ b/internal/config/revproxy.go
@@ -15,11 +15,12 @@ type RenkuServicesConfig struct {
 }
 
 type RevproxyConfig struct {
-	EnableV1Services  bool
-	RenkuBaseURL      *url.URL
-	ExternalGitlabURL *url.URL
-	K8sNamespace      string
-	RenkuServices     RenkuServicesConfig
+	EnableV1Services     bool
+	EnableInternalGitlab bool
+	RenkuBaseURL         *url.URL
+	ExternalGitlabURL    *url.URL
+	K8sNamespace         string
+	RenkuServices        RenkuServicesConfig
 }
 
 type CoreSvcConfig struct {
@@ -38,6 +39,9 @@ func (r *RevproxyConfig) Validate() error {
 	}
 	if r.RenkuServices.UIServer == nil {
 		return fmt.Errorf("the proxy config is missing the url to ui-server")
+	}
+	if r.EnableV1Services && !r.EnableInternalGitlab {
+		return fmt.Errorf("enabling V1 (legacy) services but disabling the internal Gitlab is not supported in the reverse proxy config")
 	}
 
 	// Check v1 services if needed

--- a/internal/config/revproxy_test.go
+++ b/internal/config/revproxy_test.go
@@ -15,10 +15,11 @@ func getValidRevproxyConfig(t *testing.T) RevproxyConfig {
 	require.NoError(t, err)
 	renkuServicesConfig := getValidRenkuServicesConfig(t)
 	return RevproxyConfig{
-		EnableV1Services:  true,
-		RenkuBaseURL:      renkuBaseURL,
-		ExternalGitlabURL: externalGitlabURL,
-		RenkuServices:     renkuServicesConfig,
+		EnableV1Services:     true,
+		EnableInternalGitlab: true,
+		RenkuBaseURL:         renkuBaseURL,
+		ExternalGitlabURL:    externalGitlabURL,
+		RenkuServices:        renkuServicesConfig,
 	}
 }
 

--- a/internal/login/login_server_routes.go
+++ b/internal/login/login_server_routes.go
@@ -244,7 +244,7 @@ func (l *LoginServer) nextAuthStep(
 }
 
 func (l *LoginServer) getLoginSequence() (loginSequence []string) {
-	if l.config.EnableV1Services {
+	if l.config.EnableInternalGitlab {
 		return defaultLoginSequence[:]
 	} else {
 		return v2OnlyLoginSequence[:]

--- a/internal/login/login_server_routes_test.go
+++ b/internal/login/login_server_routes_test.go
@@ -48,15 +48,18 @@ func getTestConfig(loginServerPort int, authServers ...testAuthServer) (config.L
 
 	// Toggle `EnableV1Services` on if we authenticate with GitLab
 	enableV1Services := false
+	enableInternalGitlab := false
 	for _, auth := range authServers {
 		if auth.ClientID == "gitlab" {
 			enableV1Services = true
+			enableInternalGitlab = true
 		}
 	}
 
 	testConfig := config.LoginConfig{
-		EnableV1Services: enableV1Services,
-		RenkuBaseURL:     renkuBaseURL,
+		EnableInternalGitlab: enableInternalGitlab,
+		EnableV1Services:     enableV1Services,
+		RenkuBaseURL:         renkuBaseURL,
 		TokenEncryption: config.TokenEncryptionConfig{
 			Enabled:   true,
 			SecretKey: "1b195c6329ba7df1c1adf6975c71910d",


### PR DESCRIPTION
This makes it so that we can disable v1 services but still keep the internal gitlab working as it used to do with v1. This is needed so that when we turn off v1 services but we keep the internal gitlab around for a few months users are not asked to make the connection with the internal gitlab integration. And we wouldn't need to add an internal gitlab integration.

/deploy renku=release-2.8.0 extra-values=enableV1Services=false,enableInternalGitlab=true