### PR TITLE
feat: do not swap authorization headers

### DIFF
--- a/internal/sessions/session_store.go
+++ b/internal/sessions/session_store.go
@@ -234,8 +234,6 @@ func (sessions *SessionStore) getFromHeaders(c echo.Context) (*models.Session, e
 				TokenIDs:  tokenIDs,
 			}
 			c.Set(SessionCtxKey, &session)
-			// remove the authorization header, it will be re-populated if needed
-			c.Request().Header.Del(echo.HeaderAuthorization)
 			return &session, nil
 		}
 	}
@@ -257,8 +255,6 @@ func (sessions *SessionStore) getFromBasicAuth(c echo.Context) (*models.Session,
 				TokenIDs:  tokenIDs,
 			}
 			c.Set(SessionCtxKey, &session)
-			// remove the authorization header, it will be re-populated if needed
-			c.Request().Header.Del(echo.HeaderAuthorization)
 			return &session, nil
 		}
 	}

--- a/internal/sessions/session_store.go
+++ b/internal/sessions/session_store.go
@@ -234,6 +234,8 @@ func (sessions *SessionStore) getFromHeaders(c echo.Context) (*models.Session, e
 				TokenIDs:  tokenIDs,
 			}
 			c.Set(SessionCtxKey, &session)
+			// Re-set the authorization header
+			c.Request().Header.Set(echo.HeaderAuthorization, accessToken)
 			return &session, nil
 		}
 	}
@@ -255,6 +257,8 @@ func (sessions *SessionStore) getFromBasicAuth(c echo.Context) (*models.Session,
 				TokenIDs:  tokenIDs,
 			}
 			c.Set(SessionCtxKey, &session)
+			// Re-set the authorization header
+			c.Request().Header.Set(echo.HeaderAuthorization, basicAuthPwd)
 			return &session, nil
 		}
 	}


### PR DESCRIPTION
Use original access token when forwarding requests to backend APIs.

Note: part of gateway improvements.

/deploy renku=release-2.16.0