### PR TITLE
fix: do not trace repeated requests with Sentry

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -71,6 +71,19 @@ func main() {
 	e.Use(middleware.Recover())
 	// Sentry middleware
 	if gwConfig.Monitoring.Sentry.Enabled {
+		// NEW: Handle repeated requests
+		e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				req := c.Request()
+				isRepeatedRequest := req.Header.Get("Renku-Repeated-Request")
+				if isRepeatedRequest == "true" {
+					req.Header.Del(sentry.SentryTraceHeader)
+					req.Header.Del(sentry.SentryBaggageHeader)
+				}
+				return next(c)
+			}
+		})
+
 		e.Use(sentryecho.New(sentryecho.Options{
 			Repanic: true,
 		}))

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -77,6 +77,7 @@ func main() {
 				req := c.Request()
 				isRepeatedRequest := req.Header.Get("Renku-Repeated-Request")
 				if isRepeatedRequest == "true" {
+					slog.Info("Breaking Sentry distributed trace because request is repeated", "path", req.URL.Path)
 					req.Header.Del(sentry.SentryTraceHeader)
 					req.Header.Del(sentry.SentryBaggageHeader)
 				}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -71,20 +71,19 @@ func main() {
 	e.Use(middleware.Recover())
 	// Sentry middleware
 	if gwConfig.Monitoring.Sentry.Enabled {
-		// NEW: Handle repeated requests
+		// Handle repeated requests: strip the Sentry headers and break distributed tracing
+		// for repeated requests
 		e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c echo.Context) error {
 				req := c.Request()
 				isRepeatedRequest := req.Header.Get("Renku-Repeated-Request")
 				if isRepeatedRequest == "true" {
-					slog.Info("Breaking Sentry distributed trace because request is repeated", "path", req.URL.Path)
 					req.Header.Del(sentry.SentryTraceHeader)
 					req.Header.Del(sentry.SentryBaggageHeader)
 				}
 				return next(c)
 			}
 		})
-
 		e.Use(sentryecho.New(sentryecho.Options{
 			Repanic: true,
 		}))


### PR DESCRIPTION
See also: https://github.com/SwissDataScienceCenter/renku-ui/pull/4249

When the header `Renku-Repeated-Request: true` is present in the incoming request, we strip the Sentry headers to break distributed tracing. This avoid sending too many spans inside a single trace.

Deployed and tested -> https://github.com/SwissDataScienceCenter/renku-ui/pull/4249